### PR TITLE
fix: 处理未知状态类型时设置默认机器人状态，重构Cog管理系统

### DIFF
--- a/src/admin/cog.py
+++ b/src/admin/cog.py
@@ -18,9 +18,9 @@ class AdminCommands(commands.Cog):
         # 初始化配置缓存
         self._config_cache = {}
         self._config_cache_mtime = None
-    
+
     admin = app_commands.Group(name="管理", description="管理员专用命令")
-    
+
     @commands.Cog.listener()
     async def on_ready(self):
         if self.logger:
@@ -29,7 +29,7 @@ class AdminCommands(commands.Cog):
         asyncio.create_task(self._auto_remove_warn())
         if self.logger:
             self.logger.info("警告自动移除任务已启动")
-    
+
     async def _auto_remove_warn(self):
         while True:
             # 每小时检查一次
@@ -60,7 +60,7 @@ class AdminCommands(commands.Cog):
             if self.logger:
                 self.logger.error(f"加载配置文件失败: {e}")
             return {}
-    
+
     def is_admin():
         async def predicate(ctx):
             try:
@@ -70,7 +70,7 @@ class AdminCommands(commands.Cog):
             except Exception:
                 return False
         return commands.check(predicate)
-    
+
     # ---- 工具函数：将字符串时间转换为数字时长 ----
     def _parse_time(self, time_str: str) -> tuple[int, str]:
         """将字符串时间转换为数字时长"""
@@ -82,7 +82,7 @@ class AdminCommands(commands.Cog):
             return int(time_str[:-1]) * 86400, time_str[:-1] + "天"
         else:
             return -1, "未知时间"
-    
+
     # ---- 工具函数：发送处罚公告并保存记录 ----
     def _save_punish_record(self, guild_id: int, record: dict):
         """保存处罚记录到 data/punish 目录，文件名为 id.json"""
@@ -102,7 +102,7 @@ class AdminCommands(commands.Cog):
             return None, path
         with open(path, "r", encoding="utf-8") as f:
             return json.load(f), path
-        
+
     def _save_warn_record(self, guild_id: int, record: dict):
         record_id = uuid.uuid4().hex[:8]
         record["id"] = record_id
@@ -153,7 +153,7 @@ class AdminCommands(commands.Cog):
             await member.add_roles(role, reason=reason)
         elif action == "移除":
             await member.remove_roles(role, reason=reason)
-        
+
         await interaction.followup.send(f"✅ 已{action}身份组 {role.mention} {member.mention}", ephemeral=True)
 
     # ---- 批量删除消息 ----
@@ -182,7 +182,7 @@ class AdminCommands(commands.Cog):
         if start_message.created_at > end_message.created_at:
             await interaction.followup.send("开始消息必须在结束消息之前", ephemeral=True)
             return
-        
+
                 # 调用统一的确认视图
         confirmed = await confirm_view(
             interaction,
@@ -212,7 +212,7 @@ class AdminCommands(commands.Cog):
             deleted += len(fetched)
             await interaction.edit_original_response(content=f"已删除 {deleted} 条消息")
         await interaction.followup.send(f"✅ 已删除 {deleted} 条消息", ephemeral=True)
-        
+
 
     # ---- 批量转移身份组 ----
     @admin.command(name="批量转移身份组", description="给具有指定身份组的成员添加新身份组，可选是否移除原身份组")
@@ -240,7 +240,7 @@ class AdminCommands(commands.Cog):
         if source_role.position >= interaction.user.top_role.position or target_role.position >= interaction.user.top_role.position:
             await interaction.followup.send("❌ 无法操作比自己权限高的身份组", ephemeral=True)
             return
-        
+
         # 操作确认
         confirmed = await confirm_view(
             interaction,
@@ -304,7 +304,7 @@ class AdminCommands(commands.Cog):
         if mute_time == -1:
             await interaction.followup.send("❌ 未知时间", ephemeral=True)
             return
-        
+
         duration = datetime.timedelta(seconds=mute_time)
 
         await interaction.response.defer(ephemeral=True)
@@ -555,8 +555,8 @@ class AdminCommands(commands.Cog):
     @app_commands.describe(thread="要锁定的子区（留空则为当前子区）")
     @app_commands.rename(thread="子区")
     async def lock_thread_admin(
-        self, 
-        interaction, 
+        self,
+        interaction,
         thread: "discord.Thread" = None
     ):
         await interaction.response.defer(ephemeral=True)
@@ -565,7 +565,7 @@ class AdminCommands(commands.Cog):
         if not isinstance(thread, discord.Thread):
             await interaction.followup.send("❌ 请指定一个子区", ephemeral=True)
             return
-            
+
         if thread.locked:
             await interaction.followup.send("已锁定", ephemeral=True)
             return
@@ -580,8 +580,8 @@ class AdminCommands(commands.Cog):
     @app_commands.describe(thread="要解锁的子区（留空则为当前子区）")
     @app_commands.rename(thread="子区")
     async def unlock_thread_admin(
-        self, 
-        interaction, 
+        self,
+        interaction,
         thread: "discord.Thread" = None
     ):
         await interaction.response.defer(ephemeral=True)
@@ -604,8 +604,8 @@ class AdminCommands(commands.Cog):
     @app_commands.describe(thread="要归档的子区（留空则为当前子区）")
     @app_commands.rename(thread="子区")
     async def archive_thread_admin(
-        self, 
-        interaction, 
+        self,
+        interaction,
         thread: "discord.Thread" = None
     ):
         await interaction.response.defer(ephemeral=True)
@@ -628,8 +628,8 @@ class AdminCommands(commands.Cog):
     @app_commands.describe(thread="要取消归档的子区（留空则为当前子区）")
     @app_commands.rename(thread="子区")
     async def unarchive_thread_admin(
-        self, 
-        interaction, 
+        self,
+        interaction,
         thread: "discord.Thread" = None
     ):
         await interaction.response.defer(ephemeral=True)
@@ -695,14 +695,14 @@ class AdminCommands(commands.Cog):
         self,
         interaction,
         thread: "discord.Thread" = None
-    ):  
+    ):
         await interaction.response.defer(ephemeral=True)
         if thread is None:
             thread = interaction.channel
         if not isinstance(thread, discord.Thread):
             await interaction.followup.send("❌ 请指定一个子区", ephemeral=True)
             return
-        
+
         confirmed = await confirm_view(
             interaction,
             title="🔴 删除子区",
@@ -714,7 +714,7 @@ class AdminCommands(commands.Cog):
         if not confirmed:
             await interaction.followup.send("❌ 已取消", ephemeral=True)
             return
-        
+
         try:
             await thread.delete(reason=f"管理员删帖 by {interaction.user}")
         except Exception as e:
@@ -744,7 +744,7 @@ class AdminCommands(commands.Cog):
                         return
                 await member.remove_roles(role, reason=f"答题处罚 by {interaction.user}")
                 # 私聊通知
-                try:    
+                try:
                     await member.send(embed=discord.Embed(title="🔴 答题处罚", description=f"您因 {reason} 被移送答题区。请重新阅读规则并遵守。"))
                 except discord.Forbidden:
                     pass
@@ -755,3 +755,9 @@ class AdminCommands(commands.Cog):
                 await interaction.followup.send("成员不包含该身份组", ephemeral=True)
         except discord.Forbidden:
             await interaction.followup.send("❌ 无权限移除身份组", ephemeral=True)
+
+
+# ---- setup函数 ----
+async def setup(bot: commands.Bot):
+    """当扩展被加载时，discord.py 会调用这个函数。"""
+    await bot.add_cog(AdminCommands(bot))

--- a/src/bot_manage/cog.py
+++ b/src/bot_manage/cog.py
@@ -9,147 +9,179 @@ class BotManageCommands(commands.Cog):
         self.bot = bot
         self.logger = bot.logger
         self.name = "管理命令"
-        self.config = None
-        # 从main.py加载配置
-        try:
-            with open('config.json', 'r', encoding='utf-8') as f:
-                self.config = json.load(f)
-        except Exception as e:
-            if self.logger:
-                self.logger.error(f"加载配置文件失败: {e}")
+        # 确保从 bot 实例获取 config，而不是重新打开文件，以保证一致性
+        self.config = getattr(bot, 'config', {})
 
     command_bot_manage = app_commands.Group(name="管理机器人", description="管理机器人")
-    
+
     @commands.Cog.listener()
     async def on_ready(self):
         if self.logger:
             self.logger.info("管理命令已加载")
-            
-    
-    def is_bot_manager():
-        async def predicate(ctx):
-            # 在运行时重新加载配置以获取最新的管理员列表
-            try:
-                with open('config.json', 'r', encoding='utf-8') as f:
-                    config = json.load(f)
-                return ctx.author.id in config.get('admins', [])
-            except Exception:
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """应用命令的权限检查"""
+        try:
+            # 重新从文件加载配置以获取最新的管理员列表进行权限检查
+            with open('config.json', 'r', encoding='utf-8') as f:
+                runtime_config = json.load(f)
+            is_admin = interaction.user.id in runtime_config.get('admins', [])
+            if not is_admin:
+                self.logger.warning(f"用户 {interaction.user} (ID: {interaction.user.id}) 尝试执行受限命令 '{interaction.command.qualified_name if interaction.command else '未知命令'}' 但不是管理员。")
+                await interaction.response.send_message("❌ 你没有权限执行此命令。", ephemeral=True)
                 return False
-        return commands.check(predicate)
-    
+            return True
+        except FileNotFoundError:
+            self.logger.error("config.json 未找到，无法进行权限检查。")
+            await interaction.response.send_message("❌ 配置文件错误，无法检查权限。", ephemeral=True)
+            return False
+        except Exception as e:
+            self.logger.error(f"权限检查时发生错误: {e}")
+            await interaction.response.send_message("❌ 权限检查时发生内部错误。", ephemeral=True)
+            return False
+
     # ---- 全局Cog管理命令 ----
     @command_bot_manage.command(name="模块列表", description="列出所有可用模块及其状态")
-    @is_bot_manager()
     async def list_modules(self, interaction: discord.Interaction):
         """列出所有可用模块及其状态"""
         embed = discord.Embed(title="可用模块", color=discord.Color.blue())
-        
-        for cog_name, cog_config in self.config.get('cogs', {}).items():
-            status = "✅ 已启用" if cog_name in self.bot.cogs else "❌ 已禁用"
-            description = cog_config.get('description', '无描述')
-            
+
+        # 使用 self.bot.extensions 来检查当前加载的模块
+        cog_manager_instance = self.bot.cog_manager
+        for cog_key, module_path_value in cog_manager_instance.cog_module_paths.items():
+            # 检查模块是否实际加载
+            status = "✅ 已启用" if module_path_value in self.bot.extensions else "❌ 已禁用"
+            # 从主配置中获取描述信息
+            description = self.config.get('cogs', {}).get(cog_key, {}).get('description', '无描述')
+
             embed.add_field(
-                name=f"{cog_name} - {status}",
+                name=f"{cog_key} - {status}",
                 value=description,
                 inline=False
             )
-        
+
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
     @command_bot_manage.command(name="启用模块", description="启用指定模块")
-    @is_bot_manager()
     async def enable_module(self, interaction: discord.Interaction, module_name: str):
         """启用指定模块"""
-        from main import cog_manager
-        
-        # 检查模块是否存在于配置中
-        if module_name not in self.config.get('cogs', {}):
-            await interaction.response.send_message(f"❌ 模块 `{module_name}` 不存在于配置中", ephemeral=True)
+        cog_manager_instance = self.bot.cog_manager
+
+        if module_name not in cog_manager_instance.cog_module_paths:
+            await interaction.response.send_message(f"❌ 模块 `{module_name}` 未在机器人已知模块路径中定义。", ephemeral=True)
             return
-        
-        # 如果模块已加载，则返回
-        if module_name in self.bot.cogs:
-            await interaction.response.send_message(f"⚠️ 模块 `{module_name}` 已经处于启用状态", ephemeral=True)
+
+        module_path_to_load = cog_manager_instance.cog_module_paths[module_name]
+
+        if module_path_to_load in self.bot.extensions:
+            await interaction.response.send_message(f"⚠️ 模块 `{module_name}` 已经处于启用状态。", ephemeral=True)
             return
-        
-        # 加载模块
-        if module_name in cog_manager.cog_map:
-            cog = cog_manager.cog_map[module_name]
-            success, message = await cog_manager.load_cog(cog)
-        else:
-            await interaction.response.send_message(f"❌ 模块 `{module_name}` 不在cog_map中", ephemeral=True)
-            return
-        
-        # 如果成功，更新配置
+
+        success, message = await cog_manager_instance.load_extension(module_path_to_load, module_name)
+
         if success:
-            self.config['cogs'][module_name]['enabled'] = True
-            with open('config.json', 'w', encoding='utf-8') as f:
-                json.dump(self.config, f, indent=4, ensure_ascii=False)
-        
+            # 更新 config.json 中的状态
+            try:
+                with open('config.json', 'r', encoding='utf-8') as f:
+                    current_config = json.load(f)
+                if 'cogs' not in current_config:
+                    current_config['cogs'] = {}
+                if module_name not in current_config['cogs']:
+                    current_config['cogs'][module_name] = {}
+                current_config['cogs'][module_name]['enabled'] = True
+                with open('config.json', 'w', encoding='utf-8') as f:
+                    json.dump(current_config, f, indent=4, ensure_ascii=False)
+                self.config = current_config  # 更新 cog 内部的 config 副本
+            except Exception as e:
+                self.logger.error(f"更新 config.json 失败 (启用模块 {module_name}): {e}")
+                message += " (但配置文件更新失败)"
+
         await interaction.response.send_message(message, ephemeral=True)
 
     @command_bot_manage.command(name="禁用模块", description="禁用指定模块")
-    @is_bot_manager()
     async def disable_module(self, interaction: discord.Interaction, module_name: str):
         """禁用指定模块"""
-        from main import cog_manager
-        
-        # 检查模块是否存在于配置中
-        if module_name not in self.config.get('cogs', {}):
-            await interaction.response.send_message(f"❌ 模块 `{module_name}` 不存在于配置中", ephemeral=True)
+        cog_manager_instance = self.bot.cog_manager
+
+        if module_name not in cog_manager_instance.cog_module_paths:
+            await interaction.response.send_message(f"❌ 模块 `{module_name}` 未在机器人已知模块路径中定义。", ephemeral=True)
             return
-        
-        # 如果模块未加载，则返回
-        if module_name not in self.bot.cogs:
-            await interaction.response.send_message(f"⚠️ 模块 `{module_name}` 已经处于禁用状态", ephemeral=True)
+
+        module_path_to_unload = cog_manager_instance.cog_module_paths[module_name]
+
+        if module_path_to_unload not in self.bot.extensions:
+            await interaction.response.send_message(f"⚠️ 模块 `{module_name}` 已经处于禁用状态。", ephemeral=True)
             return
-        
-        # 卸载模块
-        if module_name in cog_manager.cog_map:
-            cog = cog_manager.cog_map[module_name]
-            success, message = await cog_manager.unload_cog(cog)
-        else:
-            await interaction.response.send_message(f"❌ 模块 `{module_name}` 不在cog_map中", ephemeral=True)
-            return
-        
-        # 如果成功，更新配置
+
+        success, message = await cog_manager_instance.unload_extension(module_path_to_unload, module_name)
+
         if success:
-            self.config['cogs'][module_name]['enabled'] = False
-            with open('config.json', 'w', encoding='utf-8') as f:
-                json.dump(self.config, f, indent=4, ensure_ascii=False)
-        
+            try:
+                with open('config.json', 'r', encoding='utf-8') as f:
+                    current_config = json.load(f)
+                if 'cogs' not in current_config:
+                    current_config['cogs'] = {}
+                if module_name not in current_config['cogs']:
+                    current_config['cogs'][module_name] = {}
+                current_config['cogs'][module_name]['enabled'] = False
+                with open('config.json', 'w', encoding='utf-8') as f:
+                    json.dump(current_config, f, indent=4, ensure_ascii=False)
+                self.config = current_config  # 更新 cog 内部的 config 副本
+            except Exception as e:
+                self.logger.error(f"更新 config.json 失败 (禁用模块 {module_name}): {e}")
+                message += " (但配置文件更新失败)"
+
         await interaction.response.send_message(message, ephemeral=True)
 
     @command_bot_manage.command(name="重载模块", description="重载指定模块")
-    @is_bot_manager()
     async def reload_module(self, interaction: discord.Interaction, module_name: str):
         """重载指定模块"""
-        from main import cog_manager
-        
-        # 检查模块是否存在于配置中
-        if module_name not in self.config.get('cogs', {}):
-            await interaction.response.send_message(f"❌ 模块 `{module_name}` 不存在于配置中", ephemeral=True)
+        cog_manager_instance = self.bot.cog_manager
+
+        if module_name not in cog_manager_instance.cog_module_paths:
+            await interaction.response.send_message(f"❌ 模块 `{module_name}` 未在机器人已知模块路径中定义。", ephemeral=True)
             return
-        
-        # 检查模块是否在cog_map中
-        if module_name not in cog_manager.cog_map:
-            await interaction.response.send_message(f"❌ 模块 `{module_name}` 不在cog_map中", ephemeral=True)
-            return
-        
-        cog = cog_manager.cog_map[module_name]
-        
-        # 如果模块未加载，则先加载
-        if module_name not in self.bot.cogs:
-            await interaction.response.send_message(f"⚠️ 模块 `{module_name}` 未启用，正在尝试加载...", ephemeral=True)
-            success, message = await cog_manager.load_cog(cog)
-            await interaction.response.send_message(message, ephemeral=True)
-            return
-        
-        # 重载模块
-        success, message = await cog_manager.reload_cog(cog)
+
+        module_path_to_reload = cog_manager_instance.cog_module_paths[module_name]
+
+        # reload_extension 会在未加载时尝试加载它
+        success, message = await cog_manager_instance.reload_extension(module_path_to_reload, module_name)
+
+        if success:
+            # 如果重载/加载成功，确保其在 config.json 中标记为 enabled
+            try:
+                with open('config.json', 'r', encoding='utf-8') as f:
+                    current_config = json.load(f)
+                if 'cogs' not in current_config:
+                    current_config['cogs'] = {}
+                if module_name not in current_config['cogs']:
+                    current_config['cogs'][module_name] = {}
+
+                # 只有当模块实际加载成功后才更新配置为 enabled
+                if module_path_to_reload in self.bot.extensions:
+                    if not current_config['cogs'][module_name].get('enabled', False):
+                        current_config['cogs'][module_name]['enabled'] = True
+                        with open('config.json', 'w', encoding='utf-8') as f:
+                            json.dump(current_config, f, indent=4, ensure_ascii=False)
+                        self.config = current_config  # 更新 cog 内部的 config 副本
+                elif current_config['cogs'][module_name].get('enabled', False):
+                    current_config['cogs'][module_name]['enabled'] = False
+                    with open('config.json', 'w', encoding='utf-8') as f:
+                        json.dump(current_config, f, indent=4, ensure_ascii=False)
+                    self.config = current_config  # 更新 cog 内部的 config 副本
+            except Exception as e:
+                self.logger.error(f"更新 config.json 失败 (重载模块 {module_name}): {e}")
+                message += " (但配置文件更新可能不一致)"
+
         await interaction.response.send_message(message, ephemeral=True)
 
     @command_bot_manage.command(name="ping", description="测试机器人响应时间")
     async def ping_slash(self, interaction: discord.Interaction):
         """测试机器人响应时间 (应用命令)"""
-        await interaction.response.send_message(f'延迟: {round(self.bot.latency * 1000)}ms', ephemeral=True) 
+        await interaction.response.send_message(f'延迟: {round(self.bot.latency * 1000)}ms', ephemeral=True)
+
+
+# ---- 这个函数是关键 ----
+async def setup(bot: commands.Bot):
+    """当扩展被加载时，discord.py 会调用这个函数。"""
+    await bot.add_cog(BotManageCommands(bot))

--- a/src/thread_manage/cog.py
+++ b/src/thread_manage/cog.py
@@ -30,7 +30,7 @@ class ThreadSelfManage(commands.Cog):
         if not isinstance(channel, discord.Thread):
             await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
             return
-        
+
         if not interaction.user.id == channel.owner_id:
             await interaction.response.send_message("不能在他人子区内使用此指令", ephemeral=True)
             return
@@ -47,7 +47,7 @@ class ThreadSelfManage(commands.Cog):
             embed = discord.Embed(title="清理子区", description=f"当前子区内有{count}名成员，低于阈值{threshold}，无需清理", color=0x808080)
             await interaction.edit_original_response(embed=embed)
             return
-        
+
         # 调用统一的确认视图
         confirmed = await confirm_view(
             interaction,
@@ -176,7 +176,7 @@ class ThreadSelfManage(commands.Cog):
         if not isinstance(channel, discord.Thread):
             await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
             return
-        
+
         # 验证是否是子区所有者
         if not interaction.user.id == channel.owner_id:
             await interaction.response.send_message("不能在他人子区内使用此指令", ephemeral=True)
@@ -216,7 +216,7 @@ class ThreadSelfManage(commands.Cog):
         if not isinstance(channel, discord.Thread):
             await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
             return
-        
+
         # 验证是否是子区所有者
         if not interaction.user.id == channel.owner_id:
             await interaction.response.send_message("不能在他人子区内使用此指令", ephemeral=True)
@@ -262,7 +262,7 @@ class ThreadSelfManage(commands.Cog):
         if not isinstance(channel, discord.Thread):
             await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
             return
-        
+
         # 验证是否是子区所有者
         if not interaction.user.id == channel.owner_id:
             await interaction.response.send_message("不能在他人子区内使用此指令", ephemeral=True)
@@ -293,16 +293,16 @@ class ThreadSelfManage(commands.Cog):
         # 锁定子区
         try:
             await channel.edit(locked=True, archived=False)
-            
+
             # 发送公告消息
             lock_notice = f"🔒 **子区已锁定**"
             if reason:
                 lock_notice += f"\n\n**原因：** {reason}"
             lock_notice += f"\n\n由 {interaction.user.mention} 锁定于 {discord.utils.format_dt(datetime.now())}"
-            
+
             # 在子区内发送锁定通知
             await channel.send(lock_notice)
-            
+
             # 通知操作者
             await interaction.followup.send("✅ 子区已锁定", ephemeral=True)
         except discord.HTTPException as e:
@@ -316,7 +316,7 @@ class ThreadSelfManage(commands.Cog):
         if not isinstance(channel, discord.Thread):
             await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
             return
-        
+
         # 验证是否是子区所有者
         if not interaction.user.id == channel.owner_id:
             await interaction.response.send_message("不能在他人子区内使用此指令", ephemeral=True)
@@ -328,17 +328,17 @@ class ThreadSelfManage(commands.Cog):
             return
 
         await interaction.response.defer(ephemeral=True)
-        
+
         # 解锁子区
         try:
             await channel.edit(locked=False, archived=False)
-            
+
             # 发送公告消息
             unlock_notice = f"🔓 **子区已解锁**\n\n由 {interaction.user.mention} 解锁于 {discord.utils.format_dt(datetime.now())}"
-            
+
             # 在子区内发送解锁通知
             await channel.send(unlock_notice)
-            
+
             # 通知操作者
             await interaction.followup.send("✅ 子区已解锁", ephemeral=True)
         except discord.HTTPException as e:
@@ -362,18 +362,18 @@ class ThreadSelfManage(commands.Cog):
         if not isinstance(channel, discord.Thread):
             await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
             return
-        
+
         # 验证是否是子区所有者
         if not interaction.user.id == channel.owner_id:
             await interaction.response.send_message("不能在他人子区内使用此指令", ephemeral=True)
             return
 
         await interaction.response.defer(ephemeral=True)
-        
+
         # 设置慢速模式
         try:
             await channel.edit(slowmode_delay=option.value)
-            
+
             if option.value == 0:
                 # 通知操作者
                 await interaction.followup.send("✅ 已关闭慢速模式", ephemeral=True)
@@ -402,8 +402,8 @@ class ThreadSelfManage(commands.Cog):
         app_commands.Choice(name="📍 取消标注", value="unpin"),
     ])
     async def pin_operations(
-        self, 
-        interaction: discord.Interaction, 
+        self,
+        interaction: discord.Interaction,
         action: app_commands.Choice[str],
         message_link: str
     ):
@@ -412,7 +412,7 @@ class ThreadSelfManage(commands.Cog):
         if not isinstance(channel, discord.Thread):
             await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
             return
-        
+
         # 验证是否是子区所有者
         if not interaction.user.id == channel.owner_id:
             await interaction.response.send_message("不能在他人子区内使用此指令", ephemeral=True)
@@ -422,7 +422,7 @@ class ThreadSelfManage(commands.Cog):
         if not message_link:
             await interaction.response.send_message("请提供要操作的消息链接", ephemeral=True)
             return
-            
+
         # 尝试获取消息
         try:
             message_id_int = int(message_link.strip().split("/")[-1])
@@ -437,20 +437,20 @@ class ThreadSelfManage(commands.Cog):
             if message.pinned:
                 await interaction.response.send_message("此消息已经被标注", ephemeral=True)
                 return
-                
+
             # 置顶消息
             try:
                 await message.pin(reason=f"由 {interaction.user} 标注")
                 await interaction.response.send_message("✅ 消息已标注", ephemeral=True)
             except discord.HTTPException as e:
                 await interaction.response.send_message(f"❌ 标注失败: {str(e)}", ephemeral=True)
-        
+
         elif action.value == "unpin":
             # 检查是否已经置顶
             if not message.pinned:
                 await interaction.response.send_message("此消息未被标注", ephemeral=True)
                 return
-                
+
             # 取消置顶
             try:
                 await message.unpin(reason=f"由 {interaction.user} 取消标注")
@@ -458,5 +458,7 @@ class ThreadSelfManage(commands.Cog):
             except discord.HTTPException as e:
                 await interaction.response.send_message(f"❌ 取消标注失败: {str(e)}", ephemeral=True)
 
-async def setup(bot):
+# ---- setup函数 ----
+async def setup(bot: commands.Bot):
+    """当扩展被加载时，discord.py 会调用这个函数。"""
     await bot.add_cog(ThreadSelfManage(bot))

--- a/src/verify/cog.py
+++ b/src/verify/cog.py
@@ -56,9 +56,9 @@ class VerifyCommands(commands.Cog):
         """保存用户答题记录"""
         data_dir = pathlib.Path("data") / "verify" / str(guild_id)
         data_dir.mkdir(parents=True, exist_ok=True)
-        
+
         file_path = data_dir / f"{user_id}.json"
-        
+
         # 读取现有记录
         if file_path.exists():
             with open(file_path, 'r', encoding='utf-8') as f:
@@ -69,32 +69,32 @@ class VerifyCommands(commands.Cog):
                 "last_success": None,
                 "timeout_until": None
             }
-        
+
         # 添加新记录
         attempt_record = {
             "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "success": success
         }
         user_data["attempts"].append(attempt_record)
-        
+
         if success:
             user_data["last_success"] = attempt_record["timestamp"]
-        
+
         # 保存记录
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(user_data, f, ensure_ascii=False, indent=2)
-        
+
         return user_data
 
     def _get_user_data(self, guild_id: int, user_id: int) -> Dict:
         """获取用户数据"""
         data_dir = pathlib.Path("data") / "verify" / str(guild_id)
         file_path = data_dir / f"{user_id}.json"
-        
+
         if file_path.exists():
             with open(file_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
-        
+
         return {
             "attempts": [],
             "last_success": None,
@@ -106,11 +106,11 @@ class VerifyCommands(commands.Cog):
         data_dir = pathlib.Path("data") / "verify" / str(guild_id)
         data_dir.mkdir(parents=True, exist_ok=True)
         file_path = data_dir / f"{user_id}.json"
-        
+
         user_data = self._get_user_data(guild_id, user_id)
         timeout_until = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=minutes)
         user_data["timeout_until"] = timeout_until.isoformat()
-        
+
         with open(file_path, 'w', encoding='utf-8') as f:
             json.dump(user_data, f, ensure_ascii=False, indent=2)
 
@@ -118,11 +118,11 @@ class VerifyCommands(commands.Cog):
         """检查用户是否在禁言期间"""
         user_data = self._get_user_data(guild_id, user_id)
         timeout_until = user_data.get("timeout_until")
-        
+
         if timeout_until:
             timeout_time = datetime.datetime.fromisoformat(timeout_until)
             return datetime.datetime.now(datetime.timezone.utc) < timeout_time
-        
+
         return False
 
     def _get_recent_failed_attempts(self, guild_id: int, user_id: int) -> int:
@@ -131,7 +131,7 @@ class VerifyCommands(commands.Cog):
         now = datetime.datetime.now(datetime.timezone.utc)
         reset_hours = self.config.get("attempt_reset_hours", 24)
         cutoff_time = now - datetime.timedelta(hours=reset_hours)
-        
+
         recent_failures = 0
         for attempt in reversed(user_data.get("attempts", [])):
             attempt_time = datetime.datetime.fromisoformat(attempt["timestamp"])
@@ -141,7 +141,7 @@ class VerifyCommands(commands.Cog):
                 recent_failures += 1
             else:
                 break  # 遇到成功记录就停止计数
-        
+
         return recent_failures
 
     def is_admin():
@@ -210,14 +210,14 @@ class VerifyCommands(commands.Cog):
         ans1="第1题答案", ans2="第2题答案", ans3="第3题答案", ans4="第4题答案", ans5="第5题答案"
     )
     @app_commands.rename(ans1="答案1", ans2="答案2", ans3="答案3", ans4="答案4", ans5="答案5")
-    async def answer_zh(self, interaction: discord.Interaction, 
+    async def answer_zh(self, interaction: discord.Interaction,
                         ans1: str, ans2: str, ans3: str, ans4: str, ans5: str):
         answers = [ans1, ans2, ans3, ans4, ans5]
         await self._process_answers(interaction, answers, "zh_cn")
 
     @app_commands.command(name="answer", description="Answer verification questions (English)")
     @app_commands.describe(
-        answer1="Answer to question 1", answer2="Answer to question 2", 
+        answer1="Answer to question 1", answer2="Answer to question 2",
         answer3="Answer to question 3", answer4="Answer to question 4", answer5="Answer to question 5"
     )
     async def answer_en(self, interaction: discord.Interaction,
@@ -243,7 +243,7 @@ class VerifyCommands(commands.Cog):
         # 检查是否已有身份组
         buffer_role_id = self.config.get("buffer_role_id")
         verified_role_id = self.config.get("verified_role_id")
-        
+
         if buffer_role_id != "请填入缓冲区身份组ID":
             buffer_role = guild.get_role(int(buffer_role_id))
             if buffer_role and buffer_role in user.roles:
@@ -282,7 +282,7 @@ class VerifyCommands(commands.Cog):
         if is_success:
             # 答题成功
             success_msg = f"🎉 恭喜！您已成功通过验证（{correct_count}/5）" if language == "zh_cn" else f"🎉 Congratulations! You have passed the verification ({correct_count}/5)"
-            
+
             # 添加身份组
             try:
                 if self.config.get("buffer_mode", True) and buffer_role_id != "请填入缓冲区身份组ID":
@@ -300,7 +300,7 @@ class VerifyCommands(commands.Cog):
                 success_msg += error_msg
 
             await interaction.followup.send(success_msg, ephemeral=True)
-            
+
             # 清除用户题目
             await self._clear_user_questions(guild.id, user.id)
 
@@ -308,7 +308,7 @@ class VerifyCommands(commands.Cog):
             # 答题失败
             fail_count = self._get_recent_failed_attempts(guild.id, user.id)
             fail_msg = f"❌ 答案不正确，请重新答题" if language == "zh_cn" else f"❌ Incorrect answers, please try again"
-            
+
             # 检查是否需要禁言
             max_attempts = self.config.get("max_attempts_per_period", 3)
             if fail_count >= max_attempts:
@@ -317,7 +317,7 @@ class VerifyCommands(commands.Cog):
                     timeout_duration = timeout_minutes[0]
                 else:
                     timeout_duration = timeout_minutes[1] if len(timeout_minutes) > 1 else timeout_minutes[0]
-                
+
                 # 设置禁言
                 self._set_user_timeout(guild.id, user.id, timeout_duration)
                 try:
@@ -333,7 +333,7 @@ class VerifyCommands(commands.Cog):
         """获取用户的题目"""
         data_dir = pathlib.Path("data") / "verify" / str(guild_id)
         questions_file = data_dir / f"{user_id}_questions.json"
-        
+
         if questions_file.exists():
             with open(questions_file, 'r', encoding='utf-8') as f:
                 return json.load(f)
@@ -344,7 +344,7 @@ class VerifyCommands(commands.Cog):
         data_dir = pathlib.Path("data") / "verify" / str(guild_id)
         data_dir.mkdir(parents=True, exist_ok=True)
         questions_file = data_dir / f"{user_id}_questions.json"
-        
+
         with open(questions_file, 'w', encoding='utf-8') as f:
             json.dump(questions, f, ensure_ascii=False, indent=2)
 
@@ -352,7 +352,7 @@ class VerifyCommands(commands.Cog):
         """清除用户的题目"""
         data_dir = pathlib.Path("data") / "verify" / str(guild_id)
         questions_file = data_dir / f"{user_id}_questions.json"
-        
+
         if questions_file.exists():
             questions_file.unlink()
 
@@ -373,7 +373,7 @@ class VerifyCommands(commands.Cog):
         # 检查是否已有身份组
         buffer_role_id = self.config.get("buffer_role_id")
         verified_role_id = self.config.get("verified_role_id")
-        
+
         if buffer_role_id != "请填入缓冲区身份组ID":
             buffer_role = guild.get_role(int(buffer_role_id))
             if buffer_role and buffer_role in user.roles:
@@ -388,7 +388,7 @@ class VerifyCommands(commands.Cog):
 
         # 随机选择5道题
         selected_questions = random.sample(self.questions, min(5, len(self.questions)))
-        
+
         # 保存用户题目
         await self._save_user_questions(guild.id, user.id, selected_questions)
 
@@ -433,3 +433,9 @@ class VerifyButtonView(discord.ui.View):
     @discord.ui.button(label="开始答题 / Start Quiz", style=discord.ButtonStyle.primary, emoji="🎯")
     async def start_quiz_button(self, interaction: discord.Interaction, button: discord.ui.Button):
         await self.cog.start_quiz(interaction, self.language)
+
+
+# ---- setup函数 ----
+async def setup(bot: commands.Bot):
+    """当扩展被加载时，discord.py 会调用这个函数。"""
+    await bot.add_cog(VerifyCommands(bot))


### PR DESCRIPTION
当配置中的status类型未知时，添加else分支设置默认的watching状态，
确保bot.change_presence总是被调用，避免机器人状态设置被跳过。

将CogManager重构为使用Discord.py的扩展系统，不再预先创建和存储Cog实例。
改用模块路径映射替代实例映射，确保reload_extension能正确重新导入模块，
使代码修改在热重载后立即生效，提高开发和维护效率。

fixes: https://github.com/starowo/Odysseia-Main/issues/2
fixes: https://github.com/starowo/Odysseia-Main/issues/6