### PR TITLE
feat: 新增答疑组永封命令

### DIFF
--- a/src/admin/cog.py
+++ b/src/admin/cog.py
@@ -12,8 +12,17 @@ from typing import List, Tuple, Optional
 
 from src.utils import dm
 from src.utils.confirm_view import confirm_view, confirm_view_embed
-from src.utils.auth import is_admin, is_senior_admin, check_admin_permission, is_admin_member, guild_only
+from src.utils.auth import (
+    is_admin,
+    is_senior_admin,
+    check_admin_permission,
+    is_admin_member,
+    is_senior_admin_member,
+    guild_only,
+)
 from src.utils.config_helper import get_config_value, get_config_for_guild
+
+QA_PERMABAN_REASON = "有效答题处罚满 3 次"
 
 # ---- 持久视图：删除子区审批 ----
 class ThreadDeleteApprovalView(discord.ui.View):
@@ -2557,6 +2566,126 @@ class AdminCommands(commands.Cog):
                     embed=embed,
                     file=discord.File(io.BytesIO(img_bytes), filename=img_filename) if img_bytes else None,
                 )
+
+    # ---- 答疑组永封 ----
+    @app_commands.command(name="答疑组永封", description="答疑组专用永久封禁")
+    @app_commands.describe(member="要永久封禁的成员")
+    @app_commands.rename(member="成员")
+    @guild_only()
+    async def qa_ban(
+        self,
+        interaction,  # type: discord.Interaction
+        member: "discord.Member",
+    ):
+        guild = interaction.guild
+        reason = QA_PERMABAN_REASON
+
+        # 检查是否为答疑组（使用服务器特定配置）
+        qa_role_id = self.get_guild_config("qa_role_id", guild.id, 0)
+        if not qa_role_id:
+            await interaction.response.send_message("❌ 当前服务器未设置答疑组", ephemeral=True)
+            return
+        qa_role = guild.get_role(int(qa_role_id))
+        if not qa_role:
+            await interaction.response.send_message("❌ 答疑组角色不存在", ephemeral=True)
+            return
+        if qa_role not in interaction.user.roles:
+            await interaction.response.send_message("❌ 您不是答疑组成员", ephemeral=True)
+            return
+
+        if member.id == interaction.user.id:
+            await interaction.response.send_message("❌ 不能封禁自己", ephemeral=True)
+            return
+        if member.bot:
+            await interaction.response.send_message("❌ 不能封禁机器人", ephemeral=True)
+            return
+        if qa_role in member.roles:
+            await interaction.response.send_message("❌ 不能封禁答疑组成员", ephemeral=True)
+            return
+        if is_senior_admin_member(member):
+            await interaction.response.send_message("❌ 不能封禁高级管理组成员", ephemeral=True)
+            return
+        if is_admin_member(member):
+            await interaction.response.send_message("❌ 不能封禁管理组成员", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        confirm_embed = discord.Embed(
+            title="⛔ 永久封禁 - 确认",
+            description="确定要永久封禁此用户吗？此操作不可撤销。",
+            color=discord.Color.red()
+        )
+        confirm_embed.set_thumbnail(url=member.display_avatar.url)
+        confirm_embed.add_field(name="昵称", value=member.display_name, inline=True)
+        confirm_embed.add_field(name="用户名", value=member.name, inline=True)
+        confirm_embed.add_field(name="用户ID", value=str(member.id), inline=True)
+        confirm_embed.add_field(name="原因", value=reason, inline=False)
+        if not await confirm_view_embed(interaction, confirm_embed, timeout=120):
+            return
+
+        try:
+            await guild.ban(member, reason=reason, delete_message_days=0)
+        except discord.Forbidden:
+            await interaction.followup.send("❌ 无权限封禁该用户", ephemeral=True)
+            return
+        except discord.NotFound:
+            await interaction.followup.send("❌ 用户不存在或已被封禁", ephemeral=True)
+            return
+
+        record_id = self._save_punish_record(guild.id, {
+            "type": "ban",
+            "user_id": member.id,
+            "moderator_id": interaction.user.id,
+            "reason": reason,
+        })
+
+        sync_cog = self.bot.get_cog("ServerSyncCommands")
+        if sync_cog:
+            await sync_cog.sync_punishment(
+                guild=guild,
+                punishment_type="ban",
+                member=member,
+                moderator=interaction.user,
+                reason=reason,
+                punishment_id=record_id,
+            )
+
+        await interaction.followup.send(f"✅ 已永久封禁 {member}。处罚ID: `{record_id}`", ephemeral=True)
+
+        try:
+            ban_embed = discord.Embed(
+                title="⛔ 永久封禁",
+                description=f"您因 **{reason}** 被 **{guild.name}** 永久封禁。如有异议，请联系管理组成员。"
+            )
+            ban_embed.set_footer(text=f"来自服务器: {guild.name}")
+            await dm.send_dm(member.guild, member, embed=ban_embed)
+        except discord.Forbidden:
+            pass
+        except Exception:
+            pass
+
+        await interaction.followup.send(
+            embed=discord.Embed(title="⛔ 永久封禁", description=f"{member.mention} 因 {reason} 被永久封禁。请注意遵守社区规则。"),
+            ephemeral=False
+        )
+
+        # 公示频道 + 答疑处罚日志（使用服务器特定配置）
+        channel_id = self.get_guild_config("punish_announce_channel_id", guild.id, 0)
+        announce_channel = guild.get_channel(int(channel_id)) if channel_id else None
+        quiz_punish_log_channel_id = self.get_guild_config("quiz_punish_log_channel_id", guild.id, 0)
+        quiz_punish_log_channel = guild.get_channel_or_thread(int(quiz_punish_log_channel_id)) if quiz_punish_log_channel_id else None
+        if announce_channel or quiz_punish_log_channel:
+            embed = discord.Embed(title="⛔ 永久封禁", color=discord.Color.red())
+            embed.add_field(name="成员", value=f"{str(member)} ({member.id})")
+            embed.add_field(name="答疑组成员", value=interaction.user.mention)
+            embed.set_thumbnail(url=member.display_avatar.url)
+            embed.add_field(name="原因", value=reason, inline=False)
+            embed.set_footer(text=f"处罚ID: {record_id}")
+            if announce_channel:
+                await announce_channel.send(embed=embed)
+            if quiz_punish_log_channel:
+                await quiz_punish_log_channel.send(embed=embed)
 
     # ---- 发送公益站地址 ----
     @app_commands.command(name="发送公益站地址", description="发送公益站地址")

--- a/tests/test_admin_qa_ban.py
+++ b/tests/test_admin_qa_ban.py
@@ -1,0 +1,239 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from src.admin.cog import AdminCommands, QA_PERMABAN_REASON
+
+
+def make_role(role_id: int):
+    role = MagicMock(spec=discord.Role)
+    role.id = role_id
+    return role
+
+
+def make_member(member_id: int, guild, roles=None, bot=False, name="User"):
+    member = MagicMock(spec=discord.Member)
+    member.id = member_id
+    member.guild = guild
+    member.roles = roles or []
+    member.bot = bot
+    member.mention = f"<@{member_id}>"
+    member.display_name = f"{name} Display"
+    member.name = name
+    member.display_avatar.url = f"https://example.com/{member_id}.png"
+    member.guild_permissions.administrator = False
+    member.__str__.return_value = f"{name}#{member_id}"
+    return member
+
+
+def make_interaction(guild, user):
+    interaction = AsyncMock(spec=discord.Interaction)
+    interaction.guild = guild
+    interaction.user = user
+    interaction.response = AsyncMock()
+    interaction.followup = AsyncMock()
+    return interaction
+
+
+@pytest.fixture
+def qa_ban_context():
+    bot = MagicMock()
+    bot.logger = MagicMock()
+    bot.get_cog.return_value = None
+
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 123
+    guild.name = "测试服务器"
+    guild.ban = AsyncMock()
+
+    qa_role = make_role(10)
+    guild.get_role.return_value = qa_role
+    guild.get_channel.return_value = None
+    guild.get_channel_or_thread.return_value = None
+
+    operator = make_member(1, guild, roles=[qa_role], name="Operator")
+    target = make_member(2, guild, roles=[], name="Target")
+    interaction = make_interaction(guild, operator)
+
+    cog = AdminCommands(bot)
+    cog.get_guild_config = MagicMock(
+        side_effect=lambda key, guild_id, default=None: {
+            "qa_role_id": qa_role.id,
+            "punish_announce_channel_id": 0,
+            "quiz_punish_log_channel_id": 0,
+        }.get(key, default)
+    )
+    cog._save_punish_record = MagicMock(return_value="abc12345")
+
+    return cog, interaction, guild, qa_role, operator, target
+
+
+async def call_qa_ban(cog, interaction, member):
+    await AdminCommands.qa_ban.callback(cog, interaction, member)
+
+
+@pytest.mark.asyncio
+async def test_qa_ban_rejects_missing_qa_role_config(qa_ban_context):
+    cog, interaction, guild, _, _, target = qa_ban_context
+    cog.get_guild_config = MagicMock(return_value=0)
+
+    await call_qa_ban(cog, interaction, target)
+
+    interaction.response.send_message.assert_called_once_with(
+        "❌ 当前服务器未设置答疑组", ephemeral=True
+    )
+    guild.ban.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_qa_ban_rejects_missing_qa_role(qa_ban_context):
+    cog, interaction, guild, _, _, target = qa_ban_context
+    guild.get_role.return_value = None
+
+    await call_qa_ban(cog, interaction, target)
+
+    interaction.response.send_message.assert_called_once_with(
+        "❌ 答疑组角色不存在", ephemeral=True
+    )
+    guild.ban.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_qa_ban_rejects_non_qa_operator(qa_ban_context):
+    cog, interaction, guild, _, operator, target = qa_ban_context
+    operator.roles = []
+
+    await call_qa_ban(cog, interaction, target)
+
+    interaction.response.send_message.assert_called_once_with(
+        "❌ 您不是答疑组成员", ephemeral=True
+    )
+    guild.ban.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target_mutator", "expected_message"),
+    [
+        (lambda ctx: ctx["operator"], "❌ 不能封禁自己"),
+        (lambda ctx: make_member(3, ctx["guild"], bot=True), "❌ 不能封禁机器人"),
+        (
+            lambda ctx: make_member(4, ctx["guild"], roles=[ctx["qa_role"]]),
+            "❌ 不能封禁答疑组成员",
+        ),
+    ],
+)
+async def test_qa_ban_rejects_protected_targets(
+    qa_ban_context,
+    target_mutator,
+    expected_message,
+):
+    cog, interaction, guild, qa_role, operator, _ = qa_ban_context
+    target = target_mutator({"guild": guild, "qa_role": qa_role, "operator": operator})
+
+    await call_qa_ban(cog, interaction, target)
+
+    interaction.response.send_message.assert_called_once_with(
+        expected_message, ephemeral=True
+    )
+    guild.ban.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_qa_ban_rejects_senior_admin_target(qa_ban_context):
+    cog, interaction, guild, _, _, target = qa_ban_context
+
+    with patch("src.admin.cog.is_senior_admin_member", return_value=True):
+        await call_qa_ban(cog, interaction, target)
+
+    interaction.response.send_message.assert_called_once_with(
+        "❌ 不能封禁高级管理组成员", ephemeral=True
+    )
+    guild.ban.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_qa_ban_rejects_admin_target(qa_ban_context):
+    cog, interaction, guild, _, _, target = qa_ban_context
+
+    with patch("src.admin.cog.is_senior_admin_member", return_value=False), patch(
+        "src.admin.cog.is_admin_member",
+        return_value=True,
+    ):
+        await call_qa_ban(cog, interaction, target)
+
+    interaction.response.send_message.assert_called_once_with(
+        "❌ 不能封禁管理组成员", ephemeral=True
+    )
+    guild.ban.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_qa_ban_cancel_confirmation_does_not_ban(qa_ban_context):
+    cog, interaction, guild, _, _, target = qa_ban_context
+
+    with patch("src.admin.cog.confirm_view_embed", new=AsyncMock(return_value=False)):
+        await call_qa_ban(cog, interaction, target)
+
+    interaction.response.defer.assert_called_once_with(ephemeral=True)
+    guild.ban.assert_not_called()
+    cog._save_punish_record.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_qa_ban_success_saves_syncs_and_announces(qa_ban_context):
+    cog, interaction, guild, _, operator, target = qa_ban_context
+    announce_channel = AsyncMock()
+    quiz_log_channel = AsyncMock()
+    guild.get_channel.return_value = announce_channel
+    guild.get_channel_or_thread.return_value = quiz_log_channel
+    cog.get_guild_config = MagicMock(
+        side_effect=lambda key, guild_id, default=None: {
+            "qa_role_id": 10,
+            "punish_announce_channel_id": 20,
+            "quiz_punish_log_channel_id": 30,
+        }.get(key, default)
+    )
+    sync_cog = MagicMock()
+    sync_cog.sync_punishment = AsyncMock()
+    cog.bot.get_cog.return_value = sync_cog
+
+    with patch(
+        "src.admin.cog.confirm_view_embed", new=AsyncMock(return_value=True)
+    ) as confirm_mock, patch(
+        "src.admin.cog.dm.send_dm",
+        new=AsyncMock(),
+    ):
+        await call_qa_ban(cog, interaction, target)
+
+    confirm_mock.assert_awaited_once()
+    guild.ban.assert_awaited_once_with(
+        target, reason=QA_PERMABAN_REASON, delete_message_days=0
+    )
+    cog._save_punish_record.assert_called_once_with(
+        guild.id,
+        {
+            "type": "ban",
+            "user_id": target.id,
+            "moderator_id": operator.id,
+            "reason": QA_PERMABAN_REASON,
+        },
+    )
+    sync_cog.sync_punishment.assert_awaited_once_with(
+        guild=guild,
+        punishment_type="ban",
+        member=target,
+        moderator=operator,
+        reason=QA_PERMABAN_REASON,
+        punishment_id="abc12345",
+    )
+    assert interaction.followup.send.await_count == 2
+
+    announce_embed = announce_channel.send.await_args.kwargs["embed"]
+    assert announce_embed.title == "⛔ 永久封禁"
+    assert announce_embed.fields[0].name == "成员"
+    assert announce_embed.fields[1].name == "答疑组成员"
+    assert announce_embed.fields[2].name == "原因"
+    assert announce_embed.footer.text == "处罚ID: abc12345"
+    quiz_log_channel.send.assert_awaited_once()


### PR DESCRIPTION
 ## 变更内容

  - 新增顶层命令 `/答疑组永封`，供答疑组成员永久封禁服务器成员，后者需仍在服务器内
  - 使用固定原因 `有效答题处罚满 3 次`
  - 复用 `/管理 永封` 的二次确认流程
  - 增加目标保护：不能封禁自己、机器人、答疑组成员、管理组/高级管理组成员
  - 封禁成功后保存处罚记录、触发双服处罚同步、发送私聊通知和处罚公示
  - 公示频道只投递到 `punish_announce_channel_id` 和 `quiz_punish_log_channel_id`

  ## 测试

  - `uv run --no-project --with-requirements requirements.txt --with-requirements
  requirements-test.txt pytest tests/test_admin_qa_ban.py --no-cov`
  - `uv run --no-project --with-requirements requirements.txt python -m compileall src
  tests`

  ## 备注

  全量 `python run_tests.py all -v` 当前会因既有 `tests/conftest.py` 的 `mock_bot`
  fixture 在新版 `unittest.mock` 下触发 `InvalidSpecError` 而失败，本 PR 的新增测试已单
  独通过。