### PR TITLE
feat: 锁帖时通过私信通知贴主

### DIFF
--- a/src/thread_manage/cog.py
+++ b/src/thread_manage/cog.py
@@ -193,6 +193,47 @@ class ThreadSelfManage(commands.Cog):
             if self.logger:
                 self.logger.error(f"论坛欢迎消息发送失败: {e}")
 
+    @commands.Cog.listener()
+    async def on_thread_update(self, before: discord.Thread, after: discord.Thread):
+        """当子区被锁定时，通过私信通知贴主。"""
+        try:
+            if before.locked or not after.locked:
+                return
+
+            owner_id = after.owner_id
+            if owner_id is None:
+                return
+
+            parent = after.parent
+            if not isinstance(parent, discord.ForumChannel):
+                return
+
+            owner = after.guild.get_member(owner_id)
+            if owner is None or owner.bot:
+                return
+
+            embed = discord.Embed(
+                title="🔒 您的帖子已被锁定",
+                description=(
+                    f"您发布的帖子 **{after.name}** 已被锁定，锁定后其他人将无法发言。\n\n"
+                    f"如需解锁，可使用 `/自助管理 解锁子区 {after.id}`。"
+                ),
+                colour=discord.Colour.orange(),
+            )
+            embed.add_field(name="帖子", value=after.mention, inline=True)
+            embed.add_field(
+                name="锁定时间",
+                value=discord.utils.format_dt(datetime.now()),
+                inline=True,
+            )
+            if after.guild.icon:
+                embed.set_footer(text=after.guild.name, icon_url=after.guild.icon.url)
+
+            await dm.send_dm(after.guild, owner, embed=embed)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"锁帖通知私信发送失败: {e}")
+
     @self_manage.command(name="菜单", description="打开自助管理图形菜单（下拉选择功能）")
     async def self_manage_menu(self, interaction: discord.Interaction):
         channel = interaction.channel

--- a/tests/test_thread_lock_notify.py
+++ b/tests/test_thread_lock_notify.py
@@ -1,0 +1,134 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import discord
+
+
+class MockGuild:
+    def __init__(self, id=123456789, name="Test Guild"):
+        self.id = id
+        self.name = name
+        self.icon = None
+
+    def get_member(self, user_id):
+        if user_id == 111:
+            member = MagicMock()
+            member.id = 111
+            member.bot = False
+            return member
+        if user_id == 222:
+            member = MagicMock()
+            member.id = 222
+            member.bot = True
+            return member
+        return None
+
+
+def make_thread(locked, owner_id, parent_forum=True):
+    thread = MagicMock(spec=discord.Thread)
+    thread.locked = locked
+    thread.owner_id = owner_id
+    thread.name = "Test Thread"
+    thread.id = 999888777
+    thread.mention = "<#999888777>"
+    thread.guild = MockGuild()
+    thread.parent = MagicMock(spec=discord.ForumChannel) if parent_forum else MagicMock()
+    thread.created_at = MagicMock()
+    return thread
+
+
+class TestThreadLockNotify:
+    def setup_method(self):
+        bot = MagicMock()
+        bot.logger = MagicMock()
+        self.cog = _make_cog(bot)
+
+    def test_locked_notifies_owner(self):
+        before = make_thread(locked=False, owner_id=111)
+        after = make_thread(locked=True, owner_id=111)
+
+        with patch("src.thread_manage.cog.dm.send_dm", new_callable=AsyncMock) as mock_send:
+            import asyncio
+            asyncio.run(self.cog.on_thread_update(before, after))
+            mock_send.assert_called_once()
+
+            call_args = mock_send.call_args
+            assert call_args[0][0] == after.guild
+            embed = call_args[1]["embed"]
+            assert "已被锁定" in embed.title
+            assert "Test Thread" in embed.description
+            assert str(after.id) in embed.description
+
+    def test_already_locked_skips(self):
+        before = make_thread(locked=True, owner_id=111)
+        after = make_thread(locked=True, owner_id=111)
+
+        with patch("src.thread_manage.cog.dm.send_dm", new_callable=AsyncMock) as mock_send:
+            import asyncio
+            asyncio.run(self.cog.on_thread_update(before, after))
+            mock_send.assert_not_called()
+
+    def test_unlocked_skips(self):
+        before = make_thread(locked=False, owner_id=111)
+        after = make_thread(locked=False, owner_id=111)
+
+        with patch("src.thread_manage.cog.dm.send_dm", new_callable=AsyncMock) as mock_send:
+            import asyncio
+            asyncio.run(self.cog.on_thread_update(before, after))
+            mock_send.assert_not_called()
+
+    def test_no_owner_skips(self):
+        before = make_thread(locked=False, owner_id=None)
+        after = make_thread(locked=True, owner_id=None)
+
+        with patch("src.thread_manage.cog.dm.send_dm", new_callable=AsyncMock) as mock_send:
+            import asyncio
+            asyncio.run(self.cog.on_thread_update(before, after))
+            mock_send.assert_not_called()
+
+    def test_non_forum_skips(self):
+        before = make_thread(locked=False, owner_id=111, parent_forum=False)
+        after = make_thread(locked=True, owner_id=111, parent_forum=False)
+
+        with patch("src.thread_manage.cog.dm.send_dm", new_callable=AsyncMock) as mock_send:
+            import asyncio
+            asyncio.run(self.cog.on_thread_update(before, after))
+            mock_send.assert_not_called()
+
+    def test_bot_owner_skips(self):
+        before = make_thread(locked=False, owner_id=222)
+        after = make_thread(locked=True, owner_id=222)
+
+        with patch("src.thread_manage.cog.dm.send_dm", new_callable=AsyncMock) as mock_send:
+            import asyncio
+            asyncio.run(self.cog.on_thread_update(before, after))
+            mock_send.assert_not_called()
+
+    def test_owner_not_in_guild_skips(self):
+        before = make_thread(locked=False, owner_id=999)
+        after = make_thread(locked=True, owner_id=999)
+
+        with patch("src.thread_manage.cog.dm.send_dm", new_callable=AsyncMock) as mock_send:
+            import asyncio
+            asyncio.run(self.cog.on_thread_update(before, after))
+            mock_send.assert_not_called()
+
+    def test_dm_failure_does_not_raise(self):
+        before = make_thread(locked=False, owner_id=111)
+        after = make_thread(locked=True, owner_id=111)
+
+        with patch("src.thread_manage.cog.dm.send_dm", side_effect=Exception("DM failed")) as mock_send:
+            import asyncio
+            asyncio.run(self.cog.on_thread_update(before, after))
+            mock_send.assert_called_once()
+
+
+def _make_cog(bot):
+    from src.thread_manage.cog import ThreadSelfManage
+    cog = ThreadSelfManage.__new__(ThreadSelfManage)
+    cog.bot = bot
+    cog.logger = bot.logger
+    cog._mute_cache = {}
+    cog._config_cache = {}
+    cog._config_cache_mtime = None
+    cog.auto_clear_manager = MagicMock()
+    return cog


### PR DESCRIPTION
当论坛子区（Thread）被锁定时，通过 on_thread_update 事件监听统一捕获所有锁帖操作，向贴主发送私信通知。

覆盖的锁帖场景：

- `/自助管理 锁定并归档` 命令
- 自助管理菜单锁定
- 违禁词自动锁帖
- 管理员锁帖
- Discord 原生 UI 右键锁定
私信包含帖子名称、链接、锁定时间和解锁命令提示。