### PR TITLE
feat(thread-manage): 新增全贴禁言与分层解除机制

### DIFF
--- a/src/thread_manage/cog.py
+++ b/src/thread_manage/cog.py
@@ -13,13 +13,13 @@ from src.thread_manage.auto_clear import AutoClearManager
 from src.thread_manage.self_manage_ui import (
     ForumWelcomeView,
     SLOWMODE_OPTIONS,
-    SelfManageMainMenuView,
     SlowModeSubView,
     TagEditView,
     ThreadMuteModal,
     forum_user_opted_out,
     schedule_delete_message,
     wait_menu_confirm_on_message,
+    build_self_manage_main_menu_view,
 )
 from src.thread_manage import db
 from typing import Optional
@@ -103,6 +103,14 @@ class ThreadSelfManage(commands.Cog):
     async def can_manage_thread(self, interaction: discord.Interaction, channel: discord.Thread) -> bool:
         """检查用户是否可以管理该子区（子区所有者、协管或管理员）"""
         if await self.can_manage_as_owner(interaction.user.id, channel):
+            return True
+        return await self.is_admin(interaction)
+
+    async def can_global_thread_action(
+        self, interaction: discord.Interaction, channel: discord.Thread
+    ) -> bool:
+        """全贴操作仅允许当前帖子楼主或管理员，明确排除帖子协管。"""
+        if interaction.user.id == channel.owner_id:
             return True
         return await self.is_admin(interaction)
 
@@ -297,8 +305,84 @@ class ThreadSelfManage(commands.Cog):
         )
         await interaction.response.send_message(
             embed=embed,
-            view=SelfManageMainMenuView(self, channel),
+            view=await build_self_manage_main_menu_view(self, interaction, channel),
             ephemeral=True,
+        )
+
+    @self_manage.command(name="全贴禁言", description="在用户创建的所有历史帖子中禁言该成员")
+    @app_commands.describe(
+        member="要禁言的成员",
+        duration="时长(如10m,1h,1d，可选)",
+        reason="原因(可选)",
+    )
+    async def global_mute(
+        self,
+        interaction: discord.Interaction,
+        member: discord.Member,
+        duration: str = None,
+        reason: str = None,
+    ):
+        """直接命令入口；实际扫描、确认及写入均复用现有全贴禁言流程。"""
+        channel = interaction.channel
+        if not isinstance(channel, discord.Thread):
+            await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
+            return
+        if not await self.can_global_thread_action(interaction, channel):
+            await interaction.response.send_message(
+                "只有帖子楼主和管理组可以执行全贴禁言。", ephemeral=True
+            )
+            return
+        if member.bot:
+            await interaction.response.send_message("❌ 不能禁言机器人", ephemeral=True)
+            return
+        if member.id == interaction.user.id:
+            await interaction.response.send_message("无法禁言自己", ephemeral=True)
+            return
+        if self._is_protected_from_thread_mute(member):
+            await interaction.response.send_message("无法禁言管理组成员", ephemeral=True)
+            return
+
+        muted_until = -1
+        if duration:
+            seconds, _human = self._parse_time(duration)
+            if seconds < 0:
+                await interaction.response.send_message(
+                    "❌ 无效时长，请使用m/h/d结尾", ephemeral=True
+                )
+                return
+            muted_until = (datetime.now() + timedelta(seconds=seconds)).isoformat()
+
+        await self.menu_run_global_thread_action(
+            interaction,
+            channel,
+            member,
+            is_mute=True,
+            muted_until=muted_until,
+            reason=reason,
+            duration_label=duration or "永久",
+        )
+
+    @self_manage.command(name="撤销全贴禁言", description="恢复用户在其所有历史帖子中的发言权限")
+    @app_commands.describe(member="要撤销全贴禁言的成员")
+    async def global_unmute(
+        self, interaction: discord.Interaction, member: discord.Member
+    ):
+        """直接命令入口；实际扫描、确认及删除均复用现有全贴撤销流程。"""
+        channel = interaction.channel
+        if not isinstance(channel, discord.Thread):
+            await interaction.response.send_message("此指令仅在子区内有效", ephemeral=True)
+            return
+        if not await self.can_global_thread_action(interaction, channel):
+            await interaction.response.send_message(
+                "只有帖子楼主和管理组可以撤销全贴禁言。", ephemeral=True
+            )
+            return
+
+        await self.menu_run_global_thread_action(
+            interaction,
+            channel,
+            member,
+            is_mute=False,
         )
 
     async def menu_run_lock(self, interaction: discord.Interaction, channel: discord.Thread):
@@ -380,6 +464,204 @@ class ThreadSelfManage(commands.Cog):
                 await interaction.followup.send(f"❌ 删除失败: {str(e)}", ephemeral=True)
             except Exception:
                 pass
+
+    async def _find_owned_forum_threads(
+        self, guild: discord.Guild, owner_id: int
+    ) -> list[discord.Thread]:
+        """查找用户创建的全部活动及公开归档论坛帖子，并按帖子 ID 去重。"""
+        found: dict[int, discord.Thread] = {}
+        for forum in guild.channels:
+            if not isinstance(forum, discord.ForumChannel):
+                continue
+
+            # 活动帖来自频道缓存，不额外请求 Discord API。
+            for thread in forum.threads:
+                if thread.owner_id == owner_id:
+                    found[thread.id] = thread
+
+            try:
+                async for thread in forum.archived_threads(limit=None):
+                    if thread.owner_id == owner_id:
+                        found[thread.id] = thread
+            except (discord.Forbidden, discord.HTTPException) as e:
+                if self.logger:
+                    self.logger.warning(
+                        f"读取论坛归档帖失败: guild={guild.id} forum={forum.id} - {e}"
+                    )
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(
+                        f"读取论坛归档帖异常: guild={guild.id} forum={forum.id} - {e}"
+                    )
+
+            # 多论坛连续分页时主动让出事件循环，降低 API 突发请求压力。
+            await asyncio.sleep(0.25)
+
+        return list(found.values())
+
+    async def _apply_global_thread_mute(
+        self,
+        threads: list[discord.Thread],
+        member: discord.Member,
+        actor: discord.abc.User,
+        *,
+        muted_until=-1,
+        reason: Optional[str] = "全贴禁言",
+        duration_label: str = "永久",
+        announce_thread_id: Optional[int] = None,
+    ) -> int:
+        """复用单帖禁言函数，在楼主的全部历史帖子中禁言目标用户。"""
+        affected = 0
+        for index, thread in enumerate(threads, start=1):
+            try:
+                if await self._mute_thread_user(
+                    thread,
+                    member,
+                    muted_until=muted_until,
+                    reason=reason,
+                    actor=actor,
+                    # 仅在执行指令的当前帖子公示，其他帖子静默写入禁言。
+                    announce=thread.id == announce_thread_id,
+                    duration_label=duration_label,
+                    announcement_title="🔒 全贴禁言",
+                    scope="global",
+                ):
+                    affected += 1
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(
+                        f"全贴禁言单帖处理失败: thread={thread.id} user={member.id} - {e}"
+                    )
+            if index % 10 == 0:
+                await asyncio.sleep(0.5)
+        return affected
+
+    async def _apply_global_thread_unmute(
+        self,
+        threads: list[discord.Thread],
+        member: discord.Member,
+        actor: discord.abc.User,
+        *,
+        announce_thread_id: Optional[int] = None,
+    ) -> tuple[int, int]:
+        """复用解除函数，仅清除全贴层并统计仍有单帖层的帖子。"""
+        affected = 0
+        still_single = 0
+        for index, thread in enumerate(threads, start=1):
+            try:
+                guild = getattr(thread, "guild", None)
+                record = (
+                    self._mute_cache.get((guild.id, thread.id, member.id), {})
+                    if guild is not None
+                    else {}
+                )
+                single_was_active = self._is_mute_value_active(
+                    record.get("muted_until")
+                )
+                if await self._unmute_thread_user(
+                    thread,
+                    member,
+                    actor=actor,
+                    announce=thread.id == announce_thread_id,
+                    scope="global",
+                ):
+                    affected += 1
+                    if single_was_active:
+                        still_single += 1
+            except Exception as e:
+                if self.logger:
+                    self.logger.error(
+                        f"撤销全贴禁言单帖处理失败: thread={thread.id} user={member.id} - {e}"
+                    )
+            if index % 10 == 0:
+                await asyncio.sleep(0.5)
+        return affected, still_single
+
+    async def menu_run_global_thread_action(
+        self,
+        interaction: discord.Interaction,
+        channel: discord.Thread,
+        member: discord.Member,
+        *,
+        is_mute: bool,
+        muted_until=-1,
+        reason: Optional[str] = "全贴禁言",
+        duration_label: str = "永久",
+    ) -> None:
+        """执行全贴禁言或撤销流程：权限复查、扫描、确认、批量处理。"""
+        if not await self.can_global_thread_action(interaction, channel):
+            message = (
+                "只有帖子楼主和管理组可以执行全贴禁言。"
+                if is_mute
+                else "只有帖子楼主和管理组可以撤销全贴禁言。"
+            )
+            await interaction.response.send_message(message, ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            # 全贴范围属于当前帖楼主 A；member 是被禁言的目标用户 B。
+            threads = await self._find_owned_forum_threads(
+                interaction.guild, channel.owner_id
+            )
+            message = await interaction.original_response()
+            owner = interaction.guild.get_member(channel.owner_id)
+            owner_mention = owner.mention if owner else f"<@{channel.owner_id}>"
+            confirmation_details = (
+                f"**帖子楼主：** {owner_mention}\n"
+                f"**目标用户：** {member.mention}\n\n"
+                f"**将影响：** {len(threads)} 个历史帖子"
+            )
+            if is_mute:
+                confirmation_details += (
+                    f"\n\n**时长：** {duration_label}"
+                    f"\n**原因：** {reason or '未填写'}"
+                )
+            confirmed = await wait_menu_confirm_on_message(
+                message,
+                interaction.user.id,
+                title="⚠️ 确认全贴禁言" if is_mute else "⚠️ 确认撤销全贴禁言",
+                description=confirmation_details,
+                colour=discord.Colour.orange(),
+            )
+            if not confirmed:
+                return
+
+            if is_mute:
+                affected = await self._apply_global_thread_mute(
+                    threads,
+                    member,
+                    interaction.user,
+                    muted_until=muted_until,
+                    reason=reason,
+                    duration_label=duration_label,
+                    announce_thread_id=channel.id,
+                )
+                result = (
+                    "✅ **全贴禁言完成**\n\n"
+                    f"**用户：** {member.mention}\n\n"
+                    f"**影响帖子：** {affected} 个"
+                )
+            else:
+                affected, still_single = await self._apply_global_thread_unmute(
+                    threads,
+                    member,
+                    interaction.user,
+                    announce_thread_id=channel.id,
+                )
+                result = (
+                    "✅ **已撤销全贴禁言**\n\n"
+                    f"**用户：** {member.mention}\n\n"
+                    f"**撤销全贴层帖子：** {affected} 个\n\n"
+                    f"**仍有单帖禁言帖子：** {still_single} 个"
+                )
+            await message.edit(content=result, embed=None, view=None)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(
+                    f"全贴禁言流程失败: guild={interaction.guild.id} user={member.id} - {e}"
+                )
+            await interaction.followup.send(f"❌ 操作失败：{e}", ephemeral=True)
 
     async def apply_slowmode_from_menu(self, interaction: discord.Interaction, channel: discord.Thread, seconds: int):
         label = next((n for n, s in SLOWMODE_OPTIONS if s == seconds), str(seconds))
@@ -554,20 +836,15 @@ class ThreadSelfManage(commands.Cog):
         else:
             muted_until = -1
             human = "永久"
-        embed = discord.Embed(
-            title="🔒 子区禁言",
-            description=f"👤 {member.mention} 已被禁言",
-            color=discord.Color.red(),
-            timestamp=datetime.now(),
+        await self._mute_thread_user(
+            channel,
+            member,
+            muted_until=muted_until,
+            reason=reason,
+            actor=interaction.user,
+            announce=True,
+            duration_label=duration or "永久",
         )
-        embed.add_field(name="原因", value=reason if reason else "无", inline=True)
-        embed.add_field(name="时长", value=duration if duration else "永久", inline=True)
-        embed.add_field(name="执行者", value=interaction.user.mention, inline=True)
-        await channel.send(embed=embed)
-        rec = self._get_mute_record(channel.guild.id, channel.id, member.id)
-        rec["muted_until"] = muted_until
-        rec["violations"] = 0
-        await self._save_mute_record(channel.guild.id, channel.id, member.id, rec)
         msg = f"✅ 已在子区禁言 {member.mention}"
         if duration:
             msg += f" 持续 {human}"
@@ -582,17 +859,23 @@ class ThreadSelfManage(commands.Cog):
             await interaction.response.send_message("只有子区所有者或管理员可执行此操作", ephemeral=True)
             return
         await interaction.response.defer(ephemeral=True)
-        key = (channel.guild.id, channel.id, member.id)
-        record = self._mute_cache.get(key)
-        if record and record.get("muted_until"):
-            await self._save_mute_record(channel.guild.id, channel.id, member.id, None)
-            embed = discord.Embed(
-                title="🔒 子区禁言",
-                description=f"👤 {member.mention} 已被解除禁言",
-                color=discord.Color.green(),
-                timestamp=datetime.now(),
+        single_active, global_active = await self._refresh_mute_layers(
+            channel.guild.id, channel.id, member.id
+        )
+        if global_active:
+            await interaction.followup.send(
+                "该用户仍处于全贴禁言，请由帖子楼主或管理组使用 /自助管理 撤销全贴禁言。",
+                ephemeral=True,
             )
-            await channel.send(embed=embed)
+            return
+        if single_active:
+            await self._unmute_thread_user(
+                channel,
+                member,
+                actor=interaction.user,
+                announce=True,
+                scope="thread",
+            )
             await interaction.followup.send(f"✅ 已解除 {member.mention} 的子区禁言", ephemeral=True)
         else:
             await interaction.followup.send("该成员未被禁言", ephemeral=True)
@@ -1493,9 +1776,111 @@ class ThreadSelfManage(commands.Cog):
         # 从内存缓存获取或初始化
         record = self._mute_cache.get(key)
         if record is None:
-            record = {"muted_until": None, "violations": 0}
+            record = {
+                "muted_until": None,
+                "global_muted_until": None,
+                "violations": 0,
+            }
             self._mute_cache[key] = record
+        else:
+            # 兼容升级前加载到内存、尚未包含新字段的旧记录。
+            record.setdefault("global_muted_until", None)
         return record
+
+    async def _mute_thread_user(
+        self,
+        channel: discord.Thread,
+        member: discord.Member,
+        *,
+        muted_until,
+        reason: Optional[str],
+        actor: discord.abc.User,
+        announce: bool,
+        duration_label: str = "永久",
+        announcement_title: str = "🔒 子区禁言",
+        scope: str = "thread",
+    ) -> bool:
+        """统一禁言实现；scope 决定写入单帖层还是全贴层。"""
+        if scope not in {"thread", "global"}:
+            raise ValueError(f"未知禁言范围: {scope}")
+        if announce:
+            embed = discord.Embed(
+                title=announcement_title,
+                description=f"👤 {member.mention} 已被禁言",
+                color=discord.Color.red(),
+                timestamp=datetime.now(),
+            )
+            embed.add_field(name="原因", value=reason or "无", inline=True)
+            embed.add_field(name="时长", value=duration_label, inline=True)
+            embed.add_field(name="执行者", value=actor.mention, inline=True)
+            await channel.send(embed=embed)
+
+        record = self._get_mute_record(channel.guild.id, channel.id, member.id)
+        field = "global_muted_until" if scope == "global" else "muted_until"
+        record[field] = muted_until
+        record["violations"] = 0
+        await self._save_mute_record(channel.guild.id, channel.id, member.id, record)
+        return True
+
+    async def _unmute_thread_user(
+        self,
+        channel: discord.Thread,
+        member: discord.Member,
+        *,
+        actor: discord.abc.User,
+        announce: bool,
+        scope: str = "thread",
+    ) -> bool:
+        """统一解除实现；仅清除指定层，另一层不受影响。"""
+        if scope not in {"thread", "global"}:
+            raise ValueError(f"未知禁言范围: {scope}")
+        key = (channel.guild.id, channel.id, member.id)
+        record = self._mute_cache.get(key)
+        if not record:
+            return False
+
+        single_active, global_active = await self._refresh_mute_layers(
+            channel.guild.id, channel.id, member.id
+        )
+        active = global_active if scope == "global" else single_active
+        if not active:
+            return False
+
+        field = "global_muted_until" if scope == "global" else "muted_until"
+        record = self._mute_cache.get(key, record)
+        record[field] = None
+        remaining_single = self._is_mute_value_active(record.get("muted_until"))
+        remaining_global = self._is_mute_value_active(
+            record.get("global_muted_until")
+        )
+        await self._save_mute_record(
+            channel.guild.id,
+            channel.id,
+            member.id,
+            record if remaining_single or remaining_global else None,
+        )
+        if announce:
+            is_global = scope == "global"
+            embed = discord.Embed(
+                title="🔓 全贴禁言" if is_global else "🔒 子区禁言",
+                description=(
+                    f"👤 {member.mention} 已被解除全贴禁言"
+                    if is_global
+                    else f"👤 {member.mention} 已被解除禁言"
+                ),
+                color=discord.Color.green(),
+                timestamp=datetime.now(),
+            )
+            if is_global:
+                embed.add_field(name="执行者", value=actor.mention, inline=True)
+                if remaining_single:
+                    embed.add_field(
+                        name="提示",
+                        value="该用户在本帖仍有单帖禁言",
+                        inline=False,
+                    )
+            await channel.send(embed=embed)
+        return True
 
     async def _save_mute_record(self, guild_id: int, thread_id: int, user_id: int, record: dict):
         # 更新内存缓存
@@ -1521,18 +1906,53 @@ class ThreadSelfManage(commands.Cog):
         else:
             return -1, "未知时间"
 
-    async def _is_thread_muted(self, guild_id: int, thread_id: int, user_id: int) -> bool:
-        rec = self._get_mute_record(guild_id, thread_id, user_id)
-        mu = rec.get("muted_until")
-        if mu == -1:
+    @staticmethod
+    def _is_mute_value_active(value) -> bool:
+        """判断单个禁言层是否仍有效；无效值按已过期处理。"""
+        if value == -1 or value == "-1":
             return True
-        if mu:
-            until = datetime.fromisoformat(mu)
-            if datetime.now() < until:
-                return True
-            await self._save_mute_record(guild_id, thread_id, user_id, None)
+        if not value:
             return False
-        return False
+        try:
+            return datetime.now() < datetime.fromisoformat(str(value))
+        except (TypeError, ValueError):
+            return False
+
+    async def _refresh_mute_layers(
+        self, guild_id: int, thread_id: int, user_id: int
+    ) -> tuple[bool, bool]:
+        """分别清理已到期层，返回（单帖层有效，全贴层有效）。"""
+        key = (guild_id, thread_id, user_id)
+        record = self._mute_cache.get(key)
+        if not record:
+            return False, False
+
+        record.setdefault("global_muted_until", None)
+        single_value = record.get("muted_until")
+        global_value = record.get("global_muted_until")
+        single_active = self._is_mute_value_active(single_value)
+        global_active = self._is_mute_value_active(global_value)
+        changed = False
+        if single_value is not None and not single_active:
+            record["muted_until"] = None
+            changed = True
+        if global_value is not None and not global_active:
+            record["global_muted_until"] = None
+            changed = True
+        if changed:
+            await self._save_mute_record(
+                guild_id,
+                thread_id,
+                user_id,
+                record if single_active or global_active else None,
+            )
+        return single_active, global_active
+
+    async def _is_thread_muted(self, guild_id: int, thread_id: int, user_id: int) -> bool:
+        single_active, global_active = await self._refresh_mute_layers(
+            guild_id, thread_id, user_id
+        )
+        return single_active or global_active
 
     async def _increment_violations(self, guild_id: int, thread_id: int, user_id: int) -> int:
         rec = self._get_mute_record(guild_id, thread_id, user_id)
@@ -1576,9 +1996,6 @@ class ThreadSelfManage(commands.Cog):
                     return
         except Exception:
             pass
-        # 自己禁言自己
-        if user.id == channel.owner_id:
-            return
         # 检查是否在子区禁言
         if await self._is_thread_muted(guild.id, channel.id, user.id):
             # 删除消息
@@ -1678,22 +2095,15 @@ class ThreadSelfManage(commands.Cog):
             muted_until = until.isoformat()
         else:
             muted_until = -1 # 永久禁言
-        # 子区内公示
-        embed = discord.Embed(
-            title="🔒 子区禁言",
-            description=f"👤 {member.mention} 已被禁言",
-            color=discord.Color.red(),
-            timestamp=datetime.now()
+        await self._mute_thread_user(
+            channel,
+            member,
+            muted_until=muted_until,
+            reason=reason,
+            actor=interaction.user,
+            announce=True,
+            duration_label=duration or "永久",
         )
-        embed.add_field(name="原因", value=reason if reason else "无", inline=True)
-        embed.add_field(name="时长", value=duration if duration else "永久", inline=True)
-        embed.add_field(name="执行者", value=interaction.user.mention, inline=True)
-        await channel.send(embed=embed)
-
-        rec = self._get_mute_record(channel.guild.id, channel.id, member.id)
-        rec['muted_until'] = muted_until
-        rec['violations'] = 0
-        await self._save_mute_record(channel.guild.id, channel.id, member.id, rec)
         msg = f"✅ 已在子区禁言 {member.mention}"
         if duration:
             msg += f" 持续 {human}"
@@ -1711,18 +2121,23 @@ class ThreadSelfManage(commands.Cog):
         if not await self.can_manage_thread(interaction, channel):
             await interaction.response.send_message("只有子区所有者或管理员可执行此操作", ephemeral=True)
             return
-        key = (channel.guild.id, channel.id, member.id)
-        record = self._mute_cache.get(key)
-        if record and record.get("muted_until"):
-            await self._save_mute_record(channel.guild.id, channel.id, member.id, None)
-            # 子区内公示
-            embed = discord.Embed(
-                title="🔒 子区禁言",
-                description=f"👤 {member.mention} 已被解除禁言",
-                color=discord.Color.green(),
-                timestamp=datetime.now()
+        single_active, global_active = await self._refresh_mute_layers(
+            channel.guild.id, channel.id, member.id
+        )
+        if global_active:
+            await interaction.response.send_message(
+                "该用户仍处于全贴禁言，请由帖子楼主或管理组使用 /自助管理 撤销全贴禁言。",
+                ephemeral=True,
             )
-            await channel.send(embed=embed)
+            return
+        if single_active:
+            await self._unmute_thread_user(
+                channel,
+                member,
+                actor=interaction.user,
+                announce=True,
+                scope="thread",
+            )
             await interaction.response.send_message(f"✅ 已解除 {member.mention} 的子区禁言", ephemeral=True)
         else:
             await interaction.response.send_message("该成员未被禁言", ephemeral=True)
@@ -1991,4 +2406,3 @@ class ThreadSelfManage(commands.Cog):
             embed.add_field(name="协管成员", value="当前没有协管", inline=False)
 
         await interaction.response.send_message(embed=embed, ephemeral=True)
-

--- a/src/thread_manage/db.py
+++ b/src/thread_manage/db.py
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS thread_mutes (
     thread_id INTEGER NOT NULL,
     user_id INTEGER NOT NULL,
     muted_until INTEGER,
+    global_muted_until TEXT,
     violations INTEGER DEFAULT 0,
     PRIMARY KEY (guild_id, thread_id, user_id)
 );
@@ -83,8 +84,20 @@ async def init_db() -> None:
     await _db.execute("PRAGMA journal_mode=WAL")
     await _db.execute("PRAGMA synchronous=NORMAL")
     await _db.executescript(_CREATE_TABLES_SQL)
+    await _ensure_thread_mute_columns()
     await _db.commit()
     _log("数据库表已就绪")
+
+
+async def _ensure_thread_mute_columns() -> None:
+    """幂等补齐禁言分层字段；旧记录继续作为单帖禁言保留。"""
+    rows = await _db.execute_fetchall("PRAGMA table_info(thread_mutes)")
+    columns = {row[1] for row in rows}
+    if "global_muted_until" not in columns:
+        await _db.execute(
+            "ALTER TABLE thread_mutes ADD COLUMN global_muted_until TEXT"
+        )
+        await _db.commit()
 
 
 async def close_db() -> None:
@@ -370,7 +383,11 @@ async def load_all_mutes() -> dict[tuple[int, int, int], dict]:
     rows = await _db.execute_fetchall("SELECT * FROM thread_mutes")
     for row in rows:
         key = (row["guild_id"], row["thread_id"], row["user_id"])
-        records[key] = {"muted_until": row["muted_until"], "violations": row["violations"]}
+        records[key] = {
+            "muted_until": row["muted_until"],
+            "global_muted_until": row["global_muted_until"],
+            "violations": row["violations"],
+        }
     return records
 
 
@@ -385,8 +402,16 @@ async def save_mute_record(guild_id: int, thread_id: int, user_id: int,
     else:
         await _db.execute(
             "INSERT OR REPLACE INTO thread_mutes "
-            "(guild_id, thread_id, user_id, muted_until, violations) VALUES (?, ?, ?, ?, ?)",
-            (guild_id, thread_id, user_id, record.get("muted_until"), record.get("violations", 0)),
+            "(guild_id, thread_id, user_id, muted_until, global_muted_until, violations) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                guild_id,
+                thread_id,
+                user_id,
+                record.get("muted_until"),
+                record.get("global_muted_until"),
+                record.get("violations", 0),
+            ),
         )
     await _db.commit()
 

--- a/src/thread_manage/self_manage_ui.py
+++ b/src/thread_manage/self_manage_ui.py
@@ -126,7 +126,13 @@ async def wait_menu_confirm_on_message(
 
 
 class SelfManageMainSelect(ui.Select):
-    def __init__(self, cog: ThreadSelfManage, thread: discord.Thread):
+    def __init__(
+        self,
+        cog: ThreadSelfManage,
+        thread: discord.Thread,
+        *,
+        show_global_actions: bool = False,
+    ):
         opts = [
             discord.SelectOption(label="慢速模式", value="slowmode", description="设置发言间隔"),
             discord.SelectOption(label="全体通知", value="announce", description="@本贴内成员"),
@@ -134,11 +140,30 @@ class SelfManageMainSelect(ui.Select):
             discord.SelectOption(label="编辑标签", value="tags", description="仅论坛频道的贴"),
             discord.SelectOption(label="锁定并归档", value="lock", description="需确认"),
             discord.SelectOption(label="删帖", value="delete_thread", description="仅贴主，两次确认"),
-            discord.SelectOption(label="更多功能", value="more", description="斜杠与右键说明"),
         ]
+        # 高级选项只在菜单创建者拥有楼主或管理员权限时加入。
+        if show_global_actions:
+            opts.extend(
+                [
+                    discord.SelectOption(
+                        label="全贴禁言用户",
+                        value="global_mute",
+                        description="禁止用户在所有历史帖子发言",
+                    ),
+                    discord.SelectOption(
+                        label="撤销全贴禁言",
+                        value="global_unmute",
+                        description="恢复用户所有帖子发言权限",
+                    ),
+                ]
+            )
+        opts.append(
+            discord.SelectOption(label="更多功能", value="more", description="斜杠与右键说明")
+        )
         super().__init__(placeholder="选择要执行的功能…", min_values=1, max_values=1, options=opts)
         self.cog = cog
         self.thread = thread
+        self.show_global_actions = show_global_actions
 
     async def callback(self, interaction: discord.Interaction):
         if not isinstance(interaction.channel, discord.Thread):
@@ -148,11 +173,34 @@ class SelfManageMainSelect(ui.Select):
         if ch.id != self.thread.id:
             await interaction.response.send_message("子区已切换，请重新打开菜单。", ephemeral=True)
             return
+
+        v = self.values[0]
+        # 高级全贴操作必须先走独立权限，不能经过包含协管的 can_manage_thread。
+        if v in {"global_mute", "global_unmute"}:
+            is_mute = v == "global_mute"
+            if not await self.cog.can_global_thread_action(interaction, ch):
+                message = (
+                    "只有帖子楼主和管理组可以执行全贴禁言。"
+                    if is_mute
+                    else "只有帖子楼主和管理组可以撤销全贴禁言。"
+                )
+                await interaction.response.send_message(message, ephemeral=True)
+                return
+            action_name = "全贴禁言用户" if is_mute else "撤销全贴禁言"
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title=action_name,
+                    description="请选择目标用户。",
+                    colour=discord.Colour.orange(),
+                ),
+                view=GlobalThreadActionUserView(self.cog, ch, is_mute=is_mute),
+            )
+            return
+
         if not await self.cog.can_manage_thread(interaction, ch):
             await interaction.response.send_message("不能在他人子区内使用此功能。", ephemeral=True)
             return
 
-        v = self.values[0]
         if v == "slowmode":
             view = SlowModeSubView(self.cog, ch)
             await interaction.response.edit_message(
@@ -192,15 +240,34 @@ class SelfManageMainSelect(ui.Select):
                 description=MORE_FEATURES_HELP,
                 colour=discord.Colour.dark_teal(),
             )
-            await interaction.response.edit_message(embed=embed, view=BackToMainView(self.cog, ch))
+            await interaction.response.edit_message(
+                embed=embed,
+                view=BackToMainView(
+                    self.cog,
+                    ch,
+                    show_global_actions=self.show_global_actions,
+                ),
+            )
             return
 
 
 class BackToMainView(ui.View):
-    def __init__(self, cog: ThreadSelfManage, thread: discord.Thread):
+    def __init__(
+        self,
+        cog: ThreadSelfManage,
+        thread: discord.Thread,
+        *,
+        show_global_actions: bool = False,
+    ):
         super().__init__(timeout=300)
         self.cog = cog
-        self.add_item(SelfManageMainSelect(cog, thread))
+        self.add_item(
+            SelfManageMainSelect(
+                cog,
+                thread,
+                show_global_actions=show_global_actions,
+            )
+        )
 
     @ui.button(label="返回主菜单", style=discord.ButtonStyle.secondary, row=1)
     async def back(self, interaction: discord.Interaction, button: ui.Button):
@@ -218,14 +285,88 @@ class BackToMainView(ui.View):
         )
         await interaction.response.edit_message(
             embed=embed,
-            view=SelfManageMainMenuView(self.cog, ch),
+            view=await build_self_manage_main_menu_view(self.cog, interaction, ch),
         )
 
 
 class SelfManageMainMenuView(ui.View):
-    def __init__(self, cog: ThreadSelfManage, thread: discord.Thread):
+    def __init__(
+        self,
+        cog: ThreadSelfManage,
+        thread: discord.Thread,
+        *,
+        show_global_actions: bool = False,
+    ):
         super().__init__(timeout=300)
-        self.add_item(SelfManageMainSelect(cog, thread))
+        self.add_item(
+            SelfManageMainSelect(
+                cog,
+                thread,
+                show_global_actions=show_global_actions,
+            )
+        )
+
+
+async def build_self_manage_main_menu_view(
+    cog: ThreadSelfManage,
+    interaction: discord.Interaction,
+    thread: discord.Thread,
+) -> SelfManageMainMenuView:
+    """按当前交互用户权限动态构建自助管理主菜单。"""
+    show_global_actions = await cog.can_global_thread_action(interaction, thread)
+    return SelfManageMainMenuView(
+        cog,
+        thread,
+        show_global_actions=show_global_actions,
+    )
+
+
+class GlobalThreadActionUserSelect(ui.UserSelect):
+    """选择需要在其全部历史帖子中禁言或解除禁言的用户。"""
+
+    def __init__(self, cog: ThreadSelfManage, thread: discord.Thread, *, is_mute: bool):
+        super().__init__(placeholder="选择目标用户…", min_values=1, max_values=1)
+        self.cog = cog
+        self.thread = thread
+        self.is_mute = is_mute
+
+    async def callback(self, interaction: discord.Interaction):
+        if not isinstance(interaction.channel, discord.Thread) or interaction.channel.id != self.thread.id:
+            await interaction.response.send_message("子区已切换，请重新打开菜单。", ephemeral=True)
+            return
+        if not await self.cog.can_global_thread_action(interaction, self.thread):
+            message = (
+                "只有帖子楼主和管理组可以执行全贴禁言。"
+                if self.is_mute
+                else "只有帖子楼主和管理组可以撤销全贴禁言。"
+            )
+            await interaction.response.send_message(message, ephemeral=True)
+            return
+
+        member = self.values[0]
+        if self.is_mute:
+            if member.bot:
+                await interaction.response.send_message("❌ 不能禁言机器人", ephemeral=True)
+                return
+            if member.id == interaction.user.id:
+                await interaction.response.send_message("无法禁言自己", ephemeral=True)
+                return
+            if self.cog._is_protected_from_thread_mute(member):
+                await interaction.response.send_message("无法禁言管理组成员", ephemeral=True)
+                return
+
+        await self.cog.menu_run_global_thread_action(
+            interaction,
+            self.thread,
+            member,
+            is_mute=self.is_mute,
+        )
+
+
+class GlobalThreadActionUserView(ui.View):
+    def __init__(self, cog: ThreadSelfManage, thread: discord.Thread, *, is_mute: bool):
+        super().__init__(timeout=300)
+        self.add_item(GlobalThreadActionUserSelect(cog, thread, is_mute=is_mute))
 
 
 class SlowModeSubSelect(ui.Select):
@@ -270,7 +411,10 @@ class SlowModeSubView(ui.View):
             description="请在下拉列表中选择要执行的操作。",
             colour=discord.Colour.blue(),
         )
-        await interaction.response.edit_message(embed=embed, view=SelfManageMainMenuView(self.cog, ch))
+        await interaction.response.edit_message(
+            embed=embed,
+            view=await build_self_manage_main_menu_view(self.cog, interaction, ch),
+        )
 
 
 class AnnounceModal(ui.Modal, title="全体通知"):
@@ -356,7 +500,10 @@ class TagEditView(ui.View):
                 description="请在下拉列表中选择要执行的操作。",
                 colour=discord.Colour.blue(),
             )
-            await itx.response.edit_message(embed=embed, view=SelfManageMainMenuView(cog, ch))
+            await itx.response.edit_message(
+                embed=embed,
+                view=await build_self_manage_main_menu_view(cog, itx, ch),
+            )
 
         back.callback = back_cb
         self.add_item(back)

--- a/tests/test_thread_global_mute.py
+++ b/tests/test_thread_global_mute.py
@@ -1,0 +1,827 @@
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+import src.thread_manage.db as thread_db
+import src.thread_manage.self_manage_ui as self_manage_ui
+from src.thread_manage.cog import ThreadSelfManage
+from src.thread_manage.self_manage_ui import SelfManageMainSelect
+
+pytestmark = pytest.mark.asyncio
+
+
+def make_cog() -> ThreadSelfManage:
+    cog = ThreadSelfManage.__new__(ThreadSelfManage)
+    cog.logger = MagicMock()
+    cog._mute_cache = {}
+    return cog
+
+
+async def test_mute_schema_migration_preserves_legacy_single_thread_records(tmp_path):
+    """新增全贴层字段时，旧 muted_until 必须原样保留为单帖禁言。"""
+    previous_db = thread_db._db
+    connection = await aiosqlite.connect(tmp_path / "legacy-mutes.db")
+    connection.row_factory = aiosqlite.Row
+    thread_db._db = connection
+    try:
+        await connection.execute(
+            """CREATE TABLE thread_mutes (
+                guild_id INTEGER NOT NULL,
+                thread_id INTEGER NOT NULL,
+                user_id INTEGER NOT NULL,
+                muted_until INTEGER,
+                violations INTEGER DEFAULT 0,
+                PRIMARY KEY (guild_id, thread_id, user_id)
+            )"""
+        )
+        await connection.execute(
+            "INSERT INTO thread_mutes VALUES (?, ?, ?, ?, ?)",
+            (1, 2, 3, -1, 4),
+        )
+        await connection.commit()
+
+        await thread_db._ensure_thread_mute_columns()
+        await thread_db._ensure_thread_mute_columns()
+
+        columns = {
+            row[1]
+            for row in await connection.execute_fetchall(
+                "PRAGMA table_info(thread_mutes)"
+            )
+        }
+        row = (
+            await connection.execute_fetchall(
+                "SELECT muted_until, global_muted_until FROM thread_mutes"
+            )
+        )[0]
+        assert "global_muted_until" in columns
+        assert tuple(row) == (-1, None)
+    finally:
+        await connection.close()
+        thread_db._db = previous_db
+
+
+async def test_layered_mute_writes_preserve_the_other_layer(monkeypatch):
+    """单帖与全贴禁言分别写入时，不得覆盖另一层。"""
+    cog = make_cog()
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_record", AsyncMock())
+    channel = SimpleNamespace(
+        id=50, guild=SimpleNamespace(id=1), send=AsyncMock()
+    )
+    member = SimpleNamespace(id=42, mention="<@42>")
+    actor = SimpleNamespace(mention="<@10>")
+
+    await cog._mute_thread_user(
+        channel,
+        member,
+        muted_until="2030-01-01T00:00:00",
+        reason=None,
+        actor=actor,
+        announce=False,
+    )
+    await cog._mute_thread_user(
+        channel,
+        member,
+        muted_until=-1,
+        reason=None,
+        actor=actor,
+        announce=False,
+        scope="global",
+    )
+
+    assert cog._mute_cache[(1, 50, 42)] == {
+        "muted_until": "2030-01-01T00:00:00",
+        "global_muted_until": -1,
+        "violations": 0,
+    }
+
+
+async def test_mute_layer_expiry_clears_only_expired_layer(monkeypatch):
+    """一层过期时只清该层，另一有效层仍继续阻止发言。"""
+    cog = make_cog()
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_record", AsyncMock())
+    cog._mute_cache[(1, 50, 42)] = {
+        "muted_until": "2000-01-01T00:00:00",
+        "global_muted_until": -1,
+        "violations": 0,
+    }
+
+    assert await cog._is_thread_muted(1, 50, 42) is True
+    assert cog._mute_cache[(1, 50, 42)]["muted_until"] is None
+    assert cog._mute_cache[(1, 50, 42)]["global_muted_until"] == -1
+
+
+@pytest.mark.parametrize(
+    ("actor_id", "owner_id", "is_admin", "expected"),
+    [
+        (10, 10, False, True),
+        (20, 10, True, True),
+        (30, 10, False, False),  # 协管不能获得全贴权限
+        (40, 10, False, False),  # 普通成员不能获得全贴权限
+    ],
+)
+async def test_global_thread_action_permission_excludes_delegate(
+    actor_id, owner_id, is_admin, expected
+):
+    cog = make_cog()
+    cog.is_admin = AsyncMock(return_value=is_admin)
+    interaction = SimpleNamespace(user=SimpleNamespace(id=actor_id))
+    thread = SimpleNamespace(owner_id=owner_id)
+
+    assert await cog.can_global_thread_action(interaction, thread) is expected
+
+
+async def test_find_owned_forum_threads_includes_active_and_archived(monkeypatch):
+    cog = make_cog()
+
+    class FakeForum:
+        def __init__(self, active, archived):
+            self.id = 99
+            self.threads = active
+            self._archived = archived
+
+        def archived_threads(self, *, limit=None):
+            async def iterator():
+                for thread in self._archived:
+                    yield thread
+
+            return iterator()
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.ForumChannel", FakeForum)
+    owned_active = SimpleNamespace(id=1, owner_id=42)
+    other_active = SimpleNamespace(id=2, owner_id=7)
+    owned_archived = SimpleNamespace(id=3, owner_id=42)
+    duplicate = SimpleNamespace(id=1, owner_id=42)
+    forum = FakeForum(
+        [owned_active, other_active],
+        [owned_archived, duplicate],
+    )
+    guild = SimpleNamespace(channels=[forum, SimpleNamespace(id=100)])
+
+    result = await cog._find_owned_forum_threads(guild, 42)
+
+    assert [thread.id for thread in result] == [1, 3]
+
+
+async def test_global_mute_scans_current_thread_owner_posts(monkeypatch):
+    """A 对 B 执行全贴禁言时，应扫描 A 的帖子而不是 B 的帖子。"""
+    cog = make_cog()
+    source = SimpleNamespace(id=100, owner_id=10)
+    target = SimpleNamespace(id=42, mention="<@42>")
+    owner = SimpleNamespace(id=10, mention="<@10>")
+    guild = SimpleNamespace(id=1, get_member=lambda user_id: owner if user_id == 10 else None)
+    message = SimpleNamespace(edit=AsyncMock())
+    interaction = SimpleNamespace(
+        guild=guild,
+        user=SimpleNamespace(id=10),
+        response=SimpleNamespace(defer=AsyncMock()),
+        original_response=AsyncMock(return_value=message),
+    )
+    cog.can_global_thread_action = AsyncMock(return_value=True)
+    cog._find_owned_forum_threads = AsyncMock(return_value=[])
+    cog._apply_global_thread_mute = AsyncMock(return_value=0)
+    monkeypatch.setattr(
+        "src.thread_manage.cog.wait_menu_confirm_on_message",
+        AsyncMock(return_value=True),
+    )
+
+    await cog.menu_run_global_thread_action(
+        interaction, source, target, is_mute=True
+    )
+
+    cog._find_owned_forum_threads.assert_awaited_once_with(guild, 10)
+
+
+async def test_global_mute_announces_only_in_source_thread():
+    """全贴禁言仅在执行指令的当前帖子公示，其他帖子保持静默。"""
+    cog = make_cog()
+    threads = [SimpleNamespace(id=100), SimpleNamespace(id=101)]
+    target = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+    cog._mute_thread_user = AsyncMock(side_effect=[True, True])
+
+    affected = await cog._apply_global_thread_mute(
+        threads,
+        target,
+        actor,
+        announce_thread_id=100,
+    )
+
+    assert affected == 2
+    calls = cog._mute_thread_user.await_args_list
+    assert calls[0].args[1] is target
+    assert calls[0].kwargs["announce"] is True
+    assert calls[0].kwargs["announcement_title"] == "🔒 全贴禁言"
+    assert calls[1].args[1] is target
+    assert calls[1].kwargs["announce"] is False
+    assert calls[1].kwargs["announcement_title"] == "🔒 全贴禁言"
+
+
+async def test_apply_global_thread_mute_reuses_single_thread_mute_helper():
+    cog = make_cog()
+    threads = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+    member = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+    cog._mute_thread_user = AsyncMock(side_effect=[True, True])
+
+    affected = await cog._apply_global_thread_mute(threads, member, actor)
+
+    assert affected == 2
+    assert cog._mute_thread_user.await_count == 2
+    for call in cog._mute_thread_user.await_args_list:
+        assert call.kwargs["muted_until"] == -1
+        assert call.kwargs["announce"] is False
+
+
+async def test_apply_global_thread_mute_forwards_custom_mute_parameters():
+    """防止批量入口丢失直接命令传入的时长、原因或显示标签。"""
+    cog = make_cog()
+    threads = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+    member = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+    cog._mute_thread_user = AsyncMock(side_effect=[True, True])
+
+    affected = await cog._apply_global_thread_mute(
+        threads,
+        member,
+        actor,
+        muted_until="2026-07-27T12:00:00",
+        reason="跨帖测试",
+        duration_label="1d",
+    )
+
+    assert affected == 2
+    for call in cog._mute_thread_user.await_args_list:
+        assert call.kwargs["muted_until"] == "2026-07-27T12:00:00"
+        assert call.kwargs["reason"] == "跨帖测试"
+        assert call.kwargs["duration_label"] == "1d"
+        assert call.kwargs["announce"] is False
+
+
+async def test_apply_global_thread_unmute_only_counts_existing_records():
+    cog = make_cog()
+    threads = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+    member = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+    cog._unmute_thread_user = AsyncMock(side_effect=[True, False])
+
+    affected = await cog._apply_global_thread_unmute(threads, member, actor)
+
+    assert affected == (1, 0)
+    assert cog._unmute_thread_user.await_count == 2
+    for call in cog._unmute_thread_user.await_args_list:
+        assert call.kwargs["announce"] is False
+        assert call.kwargs["scope"] == "global"
+
+
+async def test_global_unmute_clears_global_layer_and_preserves_single_layer(monkeypatch):
+    """撤销全贴禁言后，独立存在的单帖禁言必须继续生效。"""
+    cog = make_cog()
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_record", AsyncMock())
+    channel = SimpleNamespace(
+        id=50, guild=SimpleNamespace(id=1), send=AsyncMock()
+    )
+    member = SimpleNamespace(id=42, mention="<@42>")
+    actor = SimpleNamespace(mention="<@10>")
+    cog._mute_cache[(1, 50, 42)] = {
+        "muted_until": -1,
+        "global_muted_until": -1,
+        "violations": 0,
+    }
+
+    removed = await cog._unmute_thread_user(
+        channel,
+        member,
+        actor=actor,
+        announce=False,
+        scope="global",
+    )
+
+    assert removed is True
+    assert cog._mute_cache[(1, 50, 42)]["muted_until"] == -1
+    assert cog._mute_cache[(1, 50, 42)]["global_muted_until"] is None
+    assert await cog._is_thread_muted(1, 50, 42) is True
+
+
+async def test_global_unmute_returns_removed_and_still_single_counts():
+    """批量撤销只统计实际全贴层，并报告撤销后仍有单帖层的帖子。"""
+    cog = make_cog()
+    threads = [SimpleNamespace(id=1), SimpleNamespace(id=2), SimpleNamespace(id=3)]
+    member = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+    cog._mute_cache = {
+        (1, 1, 42): {"muted_until": -1, "global_muted_until": -1},
+        (1, 2, 42): {"muted_until": None, "global_muted_until": -1},
+        (1, 3, 42): {"muted_until": -1, "global_muted_until": None},
+    }
+    for thread in threads:
+        thread.guild = SimpleNamespace(id=1)
+    cog._unmute_thread_user = AsyncMock(side_effect=[True, True, False])
+
+    result = await cog._apply_global_thread_unmute(threads, member, actor)
+
+    assert result == (2, 1)
+    for call in cog._unmute_thread_user.await_args_list:
+        assert call.kwargs["scope"] == "global"
+
+
+async def test_global_unmute_announces_only_in_source_thread():
+    """解除全贴禁言公示只发送到执行命令的当前帖子。"""
+    cog = make_cog()
+    source = SimpleNamespace(id=1, guild=SimpleNamespace(id=7))
+    other = SimpleNamespace(id=2, guild=SimpleNamespace(id=7))
+    member = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+    cog._unmute_thread_user = AsyncMock(side_effect=[True, True])
+    cog._mute_cache = {
+        (7, 1, 42): {"muted_until": -1, "global_muted_until": -1},
+        (7, 2, 42): {"muted_until": None, "global_muted_until": -1},
+    }
+
+    await cog._apply_global_thread_unmute(
+        [source, other], member, actor, announce_thread_id=1
+    )
+
+    calls = cog._unmute_thread_user.await_args_list
+    assert calls[0].kwargs["announce"] is True
+    assert calls[0].kwargs["scope"] == "global"
+    assert calls[1].kwargs["announce"] is False
+    assert calls[1].kwargs["scope"] == "global"
+
+
+@pytest.mark.parametrize(
+    ("show_global_actions", "expected_labels"),
+    [
+        (
+            False,
+            {
+                "慢速模式",
+                "全体通知",
+                "修改标题",
+                "编辑标签",
+                "锁定并归档",
+                "删帖",
+                "更多功能",
+            },
+        ),
+        (
+            True,
+            {
+                "慢速模式",
+                "全体通知",
+                "修改标题",
+                "编辑标签",
+                "锁定并归档",
+                "删帖",
+                "全贴禁言用户",
+                "撤销全贴禁言",
+                "更多功能",
+            },
+        ),
+    ],
+)
+async def test_global_menu_options_follow_advanced_permission(
+    show_global_actions, expected_labels
+):
+    select = SelfManageMainSelect(
+        MagicMock(), MagicMock(), show_global_actions=show_global_actions
+    )
+    options = {option.label: option.description for option in select.options}
+
+    assert set(options) == expected_labels
+    if show_global_actions:
+        assert options["全贴禁言用户"] == "禁止用户在所有历史帖子发言"
+        assert options["撤销全贴禁言"] == "恢复用户所有帖子发言权限"
+
+
+@pytest.mark.parametrize("allowed", [False, True])
+async def test_main_menu_builder_uses_global_action_permission(allowed):
+    cog = SimpleNamespace(can_global_thread_action=AsyncMock(return_value=allowed))
+    interaction = SimpleNamespace(user=SimpleNamespace(id=10))
+    thread = SimpleNamespace(owner_id=10)
+
+    view = await self_manage_ui.build_self_manage_main_menu_view(
+        cog, interaction, thread
+    )
+    labels = {option.label for option in view.children[0].options}
+
+    assert ("全贴禁言用户" in labels) is allowed
+    assert ("撤销全贴禁言" in labels) is allowed
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_message"),
+    [
+        ("global_mute", "只有帖子楼主和管理组可以执行全贴禁言。"),
+        ("global_unmute", "只有帖子楼主和管理组可以撤销全贴禁言。"),
+    ],
+)
+async def test_global_menu_rejects_delegate_with_specific_message(
+    monkeypatch, value, expected_message
+):
+    class FakeThread:
+        def __init__(self):
+            self.id = 50
+
+    monkeypatch.setattr("src.thread_manage.self_manage_ui.discord.Thread", FakeThread)
+    thread = FakeThread()
+    cog = SimpleNamespace(
+        can_global_thread_action=AsyncMock(return_value=False),
+        can_manage_thread=AsyncMock(return_value=True),
+    )
+    select = SelfManageMainSelect(cog, thread)
+    select._values = [value]
+    interaction = SimpleNamespace(
+        channel=thread,
+        response=SimpleNamespace(send_message=AsyncMock(), edit_message=AsyncMock()),
+    )
+
+    await select.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once_with(
+        expected_message, ephemeral=True
+    )
+    cog.can_manage_thread.assert_not_awaited()
+
+
+async def test_single_thread_helpers_update_only_target_record(monkeypatch):
+    cog = make_cog()
+    save_record = AsyncMock()
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_record", save_record)
+    guild = SimpleNamespace(id=1)
+    channel = SimpleNamespace(id=50, guild=guild, send=AsyncMock())
+    member = SimpleNamespace(id=42, mention="<@42>")
+    actor = SimpleNamespace(mention="<@10>")
+    other_key = (1, 50, 99)
+    cog._mute_cache[other_key] = {"muted_until": -1, "violations": 0}
+
+    await cog._mute_thread_user(
+        channel,
+        member,
+        muted_until=-1,
+        reason="测试",
+        actor=actor,
+        announce=True,
+    )
+    assert cog._mute_cache[(1, 50, 42)]["muted_until"] == -1
+    channel.send.assert_awaited_once()
+    embed = channel.send.await_args.kwargs["embed"]
+    assert embed.title == "🔒 子区禁言"
+
+    removed = await cog._unmute_thread_user(
+        channel,
+        member,
+        actor=actor,
+        announce=False,
+    )
+
+    assert removed is True
+    assert (1, 50, 42) not in cog._mute_cache
+    assert cog._mute_cache[other_key]["muted_until"] == -1
+
+
+async def test_global_unmute_announcement_distinguishes_scope_and_warns_single_layer(
+    monkeypatch,
+):
+    """全贴解除公示须与单帖解除区分，并说明本帖仍有单帖禁言。"""
+    cog = make_cog()
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_record", AsyncMock())
+    channel = SimpleNamespace(
+        id=50, guild=SimpleNamespace(id=1), send=AsyncMock()
+    )
+    member = SimpleNamespace(id=42, mention="<@42>")
+    actor = SimpleNamespace(mention="<@10>")
+    cog._mute_cache[(1, 50, 42)] = {
+        "muted_until": -1,
+        "global_muted_until": -1,
+        "violations": 0,
+    }
+
+    await cog._unmute_thread_user(
+        channel,
+        member,
+        actor=actor,
+        announce=True,
+        scope="global",
+    )
+
+    embed = channel.send.await_args.kwargs["embed"]
+    assert embed.title == "🔓 全贴禁言"
+    assert embed.description == "👤 <@42> 已被解除全贴禁言"
+    assert any(field.name == "执行者" and field.value == "<@10>" for field in embed.fields)
+    assert any("本帖仍有单帖禁言" in field.value for field in embed.fields)
+
+
+async def test_single_unmute_rejects_global_layer_without_changing_record(monkeypatch):
+    """斜杠单帖解除不能绕过仍有效的全贴禁言层。"""
+    class FakeThread:
+        def __init__(self):
+            self.id = 50
+            self.guild = SimpleNamespace(id=1)
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", FakeThread)
+    channel = FakeThread()
+    cog = make_cog()
+    cog.can_manage_thread = AsyncMock(return_value=True)
+    cog._unmute_thread_user = AsyncMock()
+    original = {
+        "muted_until": -1,
+        "global_muted_until": -1,
+        "violations": 0,
+    }
+    cog._mute_cache[(1, 50, 42)] = original.copy()
+    interaction = SimpleNamespace(
+        channel=channel,
+        user=SimpleNamespace(id=30),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    member = SimpleNamespace(id=42, mention="<@42>")
+
+    await ThreadSelfManage.unmute.callback(cog, interaction, member)
+
+    interaction.response.send_message.assert_awaited_once_with(
+        "该用户仍处于全贴禁言，请由帖子楼主或管理组使用 /自助管理 撤销全贴禁言。",
+        ephemeral=True,
+    )
+    cog._unmute_thread_user.assert_not_awaited()
+    assert cog._mute_cache[(1, 50, 42)] == original
+
+
+async def test_context_single_unmute_rejects_global_layer(monkeypatch):
+    """右键单帖解除同样不能绕过全贴禁言层。"""
+    class FakeThread:
+        def __init__(self):
+            self.id = 50
+            self.guild = SimpleNamespace(id=1)
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", FakeThread)
+    channel = FakeThread()
+    cog = make_cog()
+    cog.can_manage_thread = AsyncMock(return_value=True)
+    cog._unmute_thread_user = AsyncMock()
+    cog._mute_cache[(1, 50, 42)] = {
+        "muted_until": -1,
+        "global_muted_until": -1,
+        "violations": 0,
+    }
+    interaction = SimpleNamespace(
+        channel=channel,
+        user=SimpleNamespace(id=30),
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+    member = SimpleNamespace(id=42, mention="<@42>")
+
+    await cog.thread_unmute_user_context_menu(interaction, member)
+
+    interaction.followup.send.assert_awaited_once_with(
+        "该用户仍处于全贴禁言，请由帖子楼主或管理组使用 /自助管理 撤销全贴禁言。",
+        ephemeral=True,
+    )
+    cog._unmute_thread_user.assert_not_awaited()
+
+
+async def test_thread_owner_is_still_blocked_when_mute_record_exists(monkeypatch):
+    """防止楼主豁免使全贴禁言记录失效。"""
+    cog = make_cog()
+    cog.auto_clear_manager = SimpleNamespace(
+        can_trigger_auto_clear=lambda _thread_id: False
+    )
+    cog._is_protected_from_thread_mute = MagicMock(return_value=False)
+    cog._is_thread_muted = AsyncMock(return_value=True)
+    cog._get_mute_record = MagicMock(return_value={"muted_until": -1})
+    cog._increment_violations = AsyncMock(return_value=1)
+    cog.bot = SimpleNamespace(config={})
+    monkeypatch.setattr("src.thread_manage.cog.dm.send_dm", AsyncMock())
+
+    channel = MagicMock()
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", type(channel))
+    channel.id = 50
+    channel.owner_id = 42
+    channel.name = "楼主的帖子"
+    channel.guild = SimpleNamespace(id=1, get_role=lambda _role_id: None)
+    author = SimpleNamespace(id=42, bot=False, roles=[])
+    message = SimpleNamespace(
+        author=author,
+        channel=channel,
+        guild=channel.guild,
+        delete=AsyncMock(),
+    )
+
+    await cog.on_message(message)
+
+    message.delete.assert_awaited_once()
+
+
+async def test_global_thread_slash_commands_are_registered():
+    """关键旧指令和全贴指令都必须注册到 /自助管理 命令组。"""
+    for command_name in ("禁言", "授权协管", "全贴禁言", "撤销全贴禁言"):
+        assert ThreadSelfManage.self_manage.get_command(command_name) is not None
+
+
+@pytest.mark.parametrize(
+    ("actor_id", "owner_id", "is_admin", "expected"),
+    [
+        (10, 10, False, True),
+        (20, 10, True, True),
+        (30, 10, False, False),
+    ],
+)
+async def test_delegate_settings_remain_owner_or_admin_only(
+    actor_id, owner_id, is_admin, expected
+):
+    cog = make_cog()
+    cog.is_admin = AsyncMock(return_value=is_admin)
+    interaction = SimpleNamespace(user=SimpleNamespace(id=actor_id))
+    thread = SimpleNamespace(owner_id=owner_id)
+
+    assert await cog.can_manage_delegate_settings(interaction, thread) is expected
+
+
+async def test_authorize_delegate_command_still_saves_member(monkeypatch):
+    class FakeThread:
+        def __init__(self):
+            self.id = 50
+            self.owner_id = 10
+            self.guild = SimpleNamespace(id=1)
+            self.send = AsyncMock()
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", FakeThread)
+    channel = FakeThread()
+    cog = make_cog()
+    cog.can_manage_delegate_settings = AsyncMock(return_value=True)
+    cog._load_thread_delegates = AsyncMock(return_value=set())
+    cog._save_thread_delegates = AsyncMock()
+    interaction = SimpleNamespace(
+        channel=channel,
+        user=SimpleNamespace(id=10, mention="<@10>"),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    member = SimpleNamespace(id=42, mention="<@42>", bot=False)
+
+    await ThreadSelfManage.add_thread_delegate.callback(cog, interaction, member)
+
+    cog._save_thread_delegates.assert_awaited_once_with(1, 50, {42})
+    interaction.response.send_message.assert_awaited_once_with(
+        "✅ 已授予 <@42> 本子区协管权限", ephemeral=True
+    )
+    channel.send.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("command_name", "expected_message"),
+    [
+        ("global_mute", "只有帖子楼主和管理组可以执行全贴禁言。"),
+        ("global_unmute", "只有帖子楼主和管理组可以撤销全贴禁言。"),
+    ],
+)
+async def test_global_thread_slash_command_rejects_delegate(
+    monkeypatch, command_name, expected_message
+):
+    class FakeThread:
+        owner_id = 10
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", FakeThread)
+    cog = make_cog()
+    cog.can_global_thread_action = AsyncMock(return_value=False)
+    cog.menu_run_global_thread_action = AsyncMock()
+    interaction = SimpleNamespace(
+        channel=FakeThread(),
+        user=SimpleNamespace(id=30),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    member = SimpleNamespace(id=42, bot=False)
+    command = getattr(ThreadSelfManage, command_name)
+
+    if command_name == "global_mute":
+        await command.callback(cog, interaction, member, None, None)
+    else:
+        await command.callback(cog, interaction, member)
+
+    interaction.response.send_message.assert_awaited_once_with(
+        expected_message, ephemeral=True
+    )
+    cog.menu_run_global_thread_action.assert_not_awaited()
+
+
+async def test_global_mute_slash_command_rejects_invalid_duration(monkeypatch):
+    class FakeThread:
+        owner_id = 10
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", FakeThread)
+    cog = make_cog()
+    cog.can_global_thread_action = AsyncMock(return_value=True)
+    cog._is_protected_from_thread_mute = MagicMock(return_value=False)
+    cog._parse_time = MagicMock(return_value=(-1, ""))
+    cog.menu_run_global_thread_action = AsyncMock()
+    interaction = SimpleNamespace(
+        channel=FakeThread(),
+        user=SimpleNamespace(id=10),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    member = SimpleNamespace(id=42, bot=False)
+
+    await ThreadSelfManage.global_mute.callback(
+        cog, interaction, member, "bad", "测试"
+    )
+
+    interaction.response.send_message.assert_awaited_once_with(
+        "❌ 无效时长，请使用m/h/d结尾", ephemeral=True
+    )
+    cog.menu_run_global_thread_action.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("member_id", "member_bot", "protected", "expected_message"),
+    [
+        (10, False, False, "无法禁言自己"),
+        (42, True, False, "❌ 不能禁言机器人"),
+        (42, False, True, "无法禁言管理组成员"),
+    ],
+)
+async def test_global_mute_slash_command_rejects_protected_targets(
+    monkeypatch, member_id, member_bot, protected, expected_message
+):
+    """防止直接命令绕过菜单已有的目标用户保护。"""
+    class FakeThread:
+        owner_id = 10
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", FakeThread)
+    cog = make_cog()
+    cog.can_global_thread_action = AsyncMock(return_value=True)
+    cog._is_protected_from_thread_mute = MagicMock(return_value=protected)
+    cog.menu_run_global_thread_action = AsyncMock()
+    interaction = SimpleNamespace(
+        channel=FakeThread(),
+        user=SimpleNamespace(id=10),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    member = SimpleNamespace(id=member_id, bot=member_bot)
+
+    await ThreadSelfManage.global_mute.callback(
+        cog, interaction, member, None, None
+    )
+
+    interaction.response.send_message.assert_awaited_once_with(
+        expected_message, ephemeral=True
+    )
+    cog.menu_run_global_thread_action.assert_not_awaited()
+
+
+async def test_global_mute_slash_command_forwards_duration_and_reason(monkeypatch):
+    class FakeThread:
+        owner_id = 10
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", FakeThread)
+    cog = make_cog()
+    cog.can_global_thread_action = AsyncMock(return_value=True)
+    cog._is_protected_from_thread_mute = MagicMock(return_value=False)
+    cog._parse_time = MagicMock(return_value=(86400, "1天"))
+    cog.menu_run_global_thread_action = AsyncMock()
+    interaction = SimpleNamespace(
+        channel=FakeThread(),
+        user=SimpleNamespace(id=10),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    member = SimpleNamespace(id=42, bot=False)
+    before = datetime.now() + timedelta(seconds=86395)
+
+    await ThreadSelfManage.global_mute.callback(
+        cog, interaction, member, "1d", "跨帖测试"
+    )
+
+    cog.menu_run_global_thread_action.assert_awaited_once()
+    call = cog.menu_run_global_thread_action.await_args
+    assert call.args == (interaction, interaction.channel, member)
+    assert call.kwargs["is_mute"] is True
+    assert datetime.fromisoformat(call.kwargs["muted_until"]) >= before
+    assert call.kwargs["reason"] == "跨帖测试"
+    assert call.kwargs["duration_label"] == "1d"
+
+
+async def test_global_unmute_slash_command_reuses_existing_flow(monkeypatch):
+    class FakeThread:
+        owner_id = 10
+
+    monkeypatch.setattr("src.thread_manage.cog.discord.Thread", FakeThread)
+    cog = make_cog()
+    cog.can_global_thread_action = AsyncMock(return_value=True)
+    cog.menu_run_global_thread_action = AsyncMock()
+    interaction = SimpleNamespace(
+        channel=FakeThread(),
+        user=SimpleNamespace(id=10),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    member = SimpleNamespace(id=42, bot=False)
+
+    await ThreadSelfManage.global_unmute.callback(cog, interaction, member)
+
+    cog.menu_run_global_thread_action.assert_awaited_once_with(
+        interaction,
+        interaction.channel,
+        member,
+        is_mute=False,
+    )


### PR DESCRIPTION
## 功能说明

在现有自助管理与 `thread_mutes` 禁言系统上增加“全贴禁言”和“撤销全贴禁言”，没有建立新的全局禁言系统。

- 新增 `/自助管理 全贴禁言` 与 `/自助管理 撤销全贴禁言`
- 自助管理菜单增加“全贴禁言用户”和“撤销全贴禁言”
- 全贴范围以当前帖子楼主为准，扫描该楼主创建的公开及归档论坛帖子
- 禁言支持可选时长和原因；不填写时长则永久
- 批量执行前显示影响帖子数、时长及原因并要求二次确认
- 禁言与解除公示只发送到执行命令的当前帖子，其他受影响帖子静默处理
- 批量操作继续复用现有 `_mute_thread_user()` / `_unmute_thread_user()`

## 权限控制

全贴操作使用独立的 `can_global_thread_action()`：

- 当前帖子楼主：允许
- 管理员：允许
- 帖子协管：拒绝
- 普通成员：拒绝

菜单会对协管和普通成员隐藏高级功能，同时执行入口再次检查权限，防止旧组件或恶意调用绕过。

## 分层禁言

继续复用现有 `thread_mutes` 表：

- `muted_until`：单帖禁言层
- `global_muted_until`：全贴禁言层

任意有效层都会阻止用户发言。普通单帖解除不能绕过仍有效的全贴层；必须由楼主或管理员执行“撤销全贴禁言”。撤销全贴禁言只清除全贴层，独立的单帖禁言会继续保留。

数据库迁移为幂等迁移，旧记录原样保留并解释为单帖禁言；没有新增数据表。

## 兼容性

以下原有功能保持不变：

- `/自助管理 禁言`
- `/自助管理 解除禁言`
- 右键子区禁言与解除
- 协管对当前帖子的普通管理权限
- `/自助管理 授权协管`

## 可靠性

- 遍历公开及归档帖子时去重
- 分批让出事件循环，降低 Discord API 突发压力
- 单帖失败不会中断整个批量操作，并记录详细日志
- 过期的单帖层和全贴层独立清理

## 验证

```text
python -m pytest tests/test_thread_global_mute.py tests/test_thread_lock_notify.py -q
48 passed

python -m compileall -q main.py src tests
通过
```

本 PR 仅包含 4 个文件：

- `src/thread_manage/cog.py`
- `src/thread_manage/self_manage_ui.py`
- `src/thread_manage/db.py`
- `tests/test_thread_global_mute.py`

不包含 Token、服务器 ID、用户 ID、配置文件、数据库、日志或本地测试数据。
