### PR TITLE
perf: 优化全贴禁言——加载楼主索引 + 批量/并发处理

### DIFF
--- a/src/thread_manage/cog.py
+++ b/src/thread_manage/cog.py
@@ -41,6 +41,12 @@ class ThreadSelfManage(commands.Cog):
         self._config_cache_mtime = None
         # 自动清理管理器
         self.auto_clear_manager = AutoClearManager(bot)
+        # 后台执行的全贴禁言/撤销任务引用，防止任务被垃圾回收。
+        self._global_action_tasks: set = set()
+        # 帖子楼主索引：guild_id → {owner_id: set[thread_id]}，惰性全量构建。
+        self._thread_owner_cache: dict[int, dict[int, set[int]]] = {}
+        # 已完成索引构建的 guild_id 集合；bot 重启后清空，自动回到惰性加载。
+        self._thread_owner_ready: set[int] = set()
 
     self_manage = app_commands.Group(name="自助管理", description="在贴内进行权限操作，仅限贴主、协管或管理员")
 
@@ -229,6 +235,8 @@ class ThreadSelfManage(commands.Cog):
             parent = thread.parent
             if not isinstance(parent, discord.ForumChannel):
                 return
+            # 维护楼主索引（仅服务器索引已就绪时增量更新）。
+            self._index_add_thread(thread.guild.id, thread.id, thread.owner_id)
             if await forum_user_opted_out(thread.owner_id):
                 return
             owner = thread.guild.get_member(thread.owner_id)
@@ -250,8 +258,14 @@ class ThreadSelfManage(commands.Cog):
 
     @commands.Cog.listener()
     async def on_thread_update(self, before: discord.Thread, after: discord.Thread):
-        """当子区被锁定时，通过私信通知贴主。"""
+        """维护楼主索引（owner 转移）及在子区被锁定时私信通知贴主。"""
         try:
+            # 帖子 owner 转移时同步更新索引归属。
+            if before.owner_id != after.owner_id:
+                self._index_change_owner(
+                    after.guild.id, after.id, before.owner_id, after.owner_id
+                )
+
             if before.locked or not after.locked:
                 return
 
@@ -288,6 +302,20 @@ class ThreadSelfManage(commands.Cog):
         except Exception as e:
             if self.logger:
                 self.logger.error(f"锁帖通知私信发送失败: {e}")
+
+    @commands.Cog.listener()
+    async def on_raw_thread_delete(self, payload: discord.RawThreadDeleteEvent):
+        """帖子删除时从楼主索引中移除，避免残留孤儿索引。"""
+        try:
+            self._index_remove_thread(payload.guild_id, payload.thread_id)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"索引移除帖子失败: {e}")
+
+    @commands.Cog.listener()
+    async def on_guild_remove(self, guild: discord.Guild):
+        """服务器移除时清理对应的楼主索引，避免内存泄漏。"""
+        self._index_clear_guild(guild.id)
 
     @self_manage.command(name="菜单", description="打开自助管理图形菜单（下拉选择功能）")
     async def self_manage_menu(self, interaction: discord.Interaction):
@@ -465,24 +493,22 @@ class ThreadSelfManage(commands.Cog):
             except Exception:
                 pass
 
-    async def _find_owned_forum_threads(
-        self, guild: discord.Guild, owner_id: int
-    ) -> list[discord.Thread]:
-        """查找用户创建的全部活动及公开归档论坛帖子，并按帖子 ID 去重。"""
-        found: dict[int, discord.Thread] = {}
+    async def _scan_all_forum_threads(self, guild: discord.Guild) -> dict[int, set[int]]:
+        """扫描全站论坛，构建 {owner_id: set[thread_id]} 完整索引。"""
+        owner_index: dict[int, set[int]] = {}
         for forum in guild.channels:
             if not isinstance(forum, discord.ForumChannel):
                 continue
 
             # 活动帖来自频道缓存，不额外请求 Discord API。
             for thread in forum.threads:
-                if thread.owner_id == owner_id:
-                    found[thread.id] = thread
+                if thread.owner_id is not None:
+                    owner_index.setdefault(thread.owner_id, set()).add(thread.id)
 
             try:
                 async for thread in forum.archived_threads(limit=None):
-                    if thread.owner_id == owner_id:
-                        found[thread.id] = thread
+                    if thread.owner_id is not None:
+                        owner_index.setdefault(thread.owner_id, set()).add(thread.id)
             except (discord.Forbidden, discord.HTTPException) as e:
                 if self.logger:
                     self.logger.warning(
@@ -497,84 +523,178 @@ class ThreadSelfManage(commands.Cog):
             # 多论坛连续分页时主动让出事件循环，降低 API 突发请求压力。
             await asyncio.sleep(0.25)
 
-        return list(found.values())
+        return owner_index
+
+    async def _build_owner_index(self, guild: discord.Guild) -> None:
+        """惰性为整个服务器构建楼主索引；完成后标记该 guild 已就绪。"""
+        self._thread_owner_cache[guild.id] = await self._scan_all_forum_threads(guild)
+        self._thread_owner_ready.add(guild.id)
+
+    def _lookup_owned_threads(self, guild: discord.Guild, owner_id: int) -> list[int]:
+        """从索引中取该楼主的所有帖子 ID。"""
+        index = self._thread_owner_cache.get(guild.id)
+        if not index:
+            return []
+        return list(index.get(owner_id, set()))
+
+    def _index_add_thread(self, guild_id: int, thread_id: int, owner_id: int) -> None:
+        """增量维护：仅在服务器索引已就绪后写入；否则由懒加载全量构建覆盖。"""
+        if guild_id not in self._thread_owner_ready:
+            return
+        index = self._thread_owner_cache.get(guild_id)
+        if index is None:
+            return
+        index.setdefault(owner_id, set()).add(thread_id)
+
+    def _index_remove_thread(self, guild_id: int, thread_id: int) -> None:
+        """增量维护：从索引中移除指定帖子的归属。"""
+        if guild_id not in self._thread_owner_ready:
+            return
+        index = self._thread_owner_cache.get(guild_id)
+        if not index:
+            return
+        for owner_set in index.values():
+            if thread_id in owner_set:
+                owner_set.discard(thread_id)
+
+    def _index_change_owner(
+        self,
+        guild_id: int,
+        thread_id: int,
+        old_owner_id: Optional[int],
+        new_owner_id: Optional[int],
+    ) -> None:
+        """增量维护：处理帖子 owner 转移。"""
+        if guild_id not in self._thread_owner_ready:
+            return
+        index = self._thread_owner_cache.get(guild_id)
+        if not index:
+            return
+        if old_owner_id is not None:
+            index.get(old_owner_id, set()).discard(thread_id)
+        if new_owner_id is not None:
+            index.setdefault(new_owner_id, set()).add(thread_id)
+
+    def _index_clear_guild(self, guild_id: int) -> None:
+        """服务器移除时清理对应索引，避免内存泄漏。"""
+        self._thread_owner_cache.pop(guild_id, None)
+        self._thread_owner_ready.discard(guild_id)
+
+    _GLOBAL_MUTE_CONCURRENCY = 10
+    # 帖子数超过该阈值时，全贴禁言/撤销转为后台执行，避免超过交互 15 分钟上限。
+    _GLOBAL_BACKGROUND_THRESHOLD = 100
 
     async def _apply_global_thread_mute(
         self,
-        threads: list[discord.Thread],
+        guild_id: int,
+        thread_ids: list[int],
         member: discord.Member,
         actor: discord.abc.User,
         *,
         muted_until=-1,
         reason: Optional[str] = "全贴禁言",
         duration_label: str = "永久",
-        announce_thread_id: Optional[int] = None,
+        announce_channel: Optional[discord.Thread] = None,
     ) -> int:
-        """复用单帖禁言函数，在楼主的全部历史帖子中禁言目标用户。"""
-        affected = 0
-        for index, thread in enumerate(threads, start=1):
-            try:
-                if await self._mute_thread_user(
-                    thread,
-                    member,
-                    muted_until=muted_until,
-                    reason=reason,
-                    actor=actor,
-                    # 仅在执行指令的当前帖子公示，其他帖子静默写入禁言。
-                    announce=thread.id == announce_thread_id,
-                    duration_label=duration_label,
-                    announcement_title="🔒 全贴禁言",
-                    scope="global",
-                ):
-                    affected += 1
-            except Exception as e:
-                if self.logger:
-                    self.logger.error(
-                        f"全贴禁言单帖处理失败: thread={thread.id} user={member.id} - {e}"
+        """在楼主的全部历史帖子中禁言目标用户。
+
+        应用阶段仅写本地 SQLite（无 Discord API 调用），可安全并发以加快
+        大批量场景；每帖 key 的 thread_id 均不相同，不存在同 key 竞争。
+        非公示帖仅凭 (guild_id, thread_id) 写库，不恢复 thread 对象。
+        """
+        sem = asyncio.Semaphore(self._GLOBAL_MUTE_CONCURRENCY)
+        pending: list[tuple[int, int, int, Optional[dict]]] = []
+        announce_id = announce_channel.id if announce_channel is not None else None
+
+        async def _mute_one(thread_id: int) -> bool:
+            async with sem:
+                try:
+                    if announce_channel is not None and thread_id == announce_id:
+                        return await self._mute_thread_user(
+                            announce_channel,
+                            member,
+                            muted_until=muted_until,
+                            reason=reason,
+                            actor=actor,
+                            announce=True,
+                            duration_label=duration_label,
+                            announcement_title="🔒 全贴禁言",
+                            scope="global",
+                            bulk=pending,
+                        )
+                    return await self._apply_mute_by_ids(
+                        guild_id,
+                        thread_id,
+                        member.id,
+                        muted_until,
+                        "global",
+                        pending,
                     )
-            if index % 10 == 0:
-                await asyncio.sleep(0.5)
-        return affected
+                except Exception as e:
+                    if self.logger:
+                        self.logger.error(
+                            f"全贴禁言单帖处理失败: thread={thread_id} user={member.id} - {e}"
+                        )
+                    return False
+
+        results = await asyncio.gather(*(_mute_one(tid) for tid in thread_ids))
+        try:
+            await db.save_mute_records_bulk(pending)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"全贴禁言批量写入失败: user={member.id} - {e}")
+        return sum(1 for ok in results if ok)
 
     async def _apply_global_thread_unmute(
         self,
-        threads: list[discord.Thread],
+        guild_id: int,
+        thread_ids: list[int],
         member: discord.Member,
         actor: discord.abc.User,
         *,
-        announce_thread_id: Optional[int] = None,
+        announce_channel: Optional[discord.Thread] = None,
     ) -> tuple[int, int]:
-        """复用解除函数，仅清除全贴层并统计仍有单帖层的帖子。"""
-        affected = 0
-        still_single = 0
-        for index, thread in enumerate(threads, start=1):
-            try:
-                guild = getattr(thread, "guild", None)
-                record = (
-                    self._mute_cache.get((guild.id, thread.id, member.id), {})
-                    if guild is not None
-                    else {}
-                )
-                single_was_active = self._is_mute_value_active(
-                    record.get("muted_until")
-                )
-                if await self._unmute_thread_user(
-                    thread,
-                    member,
-                    actor=actor,
-                    announce=thread.id == announce_thread_id,
-                    scope="global",
-                ):
-                    affected += 1
-                    if single_was_active:
-                        still_single += 1
-            except Exception as e:
-                if self.logger:
-                    self.logger.error(
-                        f"撤销全贴禁言单帖处理失败: thread={thread.id} user={member.id} - {e}"
+        """仅清除全贴层并统计仍有单帖层的帖子。"""
+        sem = asyncio.Semaphore(self._GLOBAL_MUTE_CONCURRENCY)
+        pending: list[tuple[int, int, int, Optional[dict]]] = []
+        announce_id = announce_channel.id if announce_channel is not None else None
+
+        async def _unmute_one(thread_id: int) -> tuple[bool, bool]:
+            async with sem:
+                try:
+                    record = self._mute_cache.get((guild_id, thread_id, member.id), {})
+                    single_was_active = self._is_mute_value_active(
+                        record.get("muted_until")
                     )
-            if index % 10 == 0:
-                await asyncio.sleep(0.5)
+                    if announce_channel is not None and thread_id == announce_id:
+                        removed = await self._unmute_thread_user(
+                            announce_channel,
+                            member,
+                            actor=actor,
+                            announce=True,
+                            scope="global",
+                            bulk=pending,
+                        )
+                        return removed, removed and single_was_active
+                    removed, still_single = await self._apply_unmute_by_ids(
+                        guild_id, thread_id, member.id, "global", pending
+                    )
+                    return removed, still_single
+                except Exception as e:
+                    if self.logger:
+                        self.logger.error(
+                            f"撤销全贴禁言单帖处理失败: thread={thread_id} user={member.id} - {e}"
+                        )
+                    return False, False
+
+        results = await asyncio.gather(*(_unmute_one(tid) for tid in thread_ids))
+        try:
+            await db.save_mute_records_bulk(pending)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"撤销全贴禁言批量写入失败: user={member.id} - {e}")
+        affected = sum(1 for removed, _ in results if removed)
+        still_single = sum(1 for removed, single in results if removed and single)
         return affected, still_single
 
     async def menu_run_global_thread_action(
@@ -601,7 +721,10 @@ class ThreadSelfManage(commands.Cog):
         await interaction.response.defer(ephemeral=True)
         try:
             # 全贴范围属于当前帖楼主 A；member 是被禁言的目标用户 B。
-            threads = await self._find_owned_forum_threads(
+            # 惰性首次为整个服务器构建楼主索引，之后所有全贴操作直接命中缓存。
+            if interaction.guild.id not in self._thread_owner_ready:
+                await self._build_owner_index(interaction.guild)
+            thread_ids = self._lookup_owned_threads(
                 interaction.guild, channel.owner_id
             )
             message = await interaction.original_response()
@@ -610,7 +733,7 @@ class ThreadSelfManage(commands.Cog):
             confirmation_details = (
                 f"**帖子楼主：** {owner_mention}\n"
                 f"**目标用户：** {member.mention}\n\n"
-                f"**将影响：** {len(threads)} 个历史帖子"
+                f"**将影响：** {len(thread_ids)} 个历史帖子"
             )
             if is_mute:
                 confirmation_details += (
@@ -627,15 +750,31 @@ class ThreadSelfManage(commands.Cog):
             if not confirmed:
                 return
 
+            # 影响帖子过多时转入后台执行，避免阻塞交互超过 15 分钟上限。
+            if len(thread_ids) > self._GLOBAL_BACKGROUND_THRESHOLD:
+                await self._start_background_global_action(
+                    interaction,
+                    message,
+                    channel,
+                    member,
+                    thread_ids=thread_ids,
+                    is_mute=is_mute,
+                    muted_until=muted_until,
+                    reason=reason,
+                    duration_label=duration_label,
+                )
+                return
+
             if is_mute:
                 affected = await self._apply_global_thread_mute(
-                    threads,
+                    interaction.guild.id,
+                    thread_ids,
                     member,
                     interaction.user,
                     muted_until=muted_until,
                     reason=reason,
                     duration_label=duration_label,
-                    announce_thread_id=channel.id,
+                    announce_channel=channel,
                 )
                 result = (
                     "✅ **全贴禁言完成**\n\n"
@@ -644,10 +783,11 @@ class ThreadSelfManage(commands.Cog):
                 )
             else:
                 affected, still_single = await self._apply_global_thread_unmute(
-                    threads,
+                    interaction.guild.id,
+                    thread_ids,
                     member,
                     interaction.user,
-                    announce_thread_id=channel.id,
+                    announce_channel=channel,
                 )
                 result = (
                     "✅ **已撤销全贴禁言**\n\n"
@@ -662,6 +802,128 @@ class ThreadSelfManage(commands.Cog):
                     f"全贴禁言流程失败: guild={interaction.guild.id} user={member.id} - {e}"
                 )
             await interaction.followup.send(f"❌ 操作失败：{e}", ephemeral=True)
+
+    async def _start_background_global_action(
+        self,
+        interaction: discord.Interaction,
+        message: discord.Message,
+        channel: discord.Thread,
+        member: discord.Member,
+        *,
+        thread_ids: list[int],
+        is_mute: bool,
+        muted_until,
+        reason: Optional[str],
+        duration_label: str,
+    ) -> None:
+        """影响帖子过多时，将全贴禁言/撤销转为后台执行并立即反馈进度。"""
+        verb = "全贴禁言" if is_mute else "撤销全贴禁言"
+        await message.edit(
+            content=(
+                f"⏳ **{verb}处理中…**\n\n"
+                f"**影响帖子：** {len(thread_ids)} 个（较多，已转入后台处理）\n\n"
+                f"完成后将通过私信通知您。"
+            ),
+            embed=None,
+            view=None,
+        )
+        task = asyncio.create_task(
+            self._run_global_action_in_background(
+                guild=interaction.guild,
+                channel=channel,
+                member=member,
+                actor=interaction.user,
+                is_mute=is_mute,
+                thread_ids=thread_ids,
+                muted_until=muted_until,
+                reason=reason,
+                duration_label=duration_label,
+            )
+        )
+        tasks = getattr(self, "_global_action_tasks", None)
+        if tasks is None:
+            tasks = set()
+            self._global_action_tasks = tasks
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+
+    async def _run_global_action_in_background(
+        self,
+        *,
+        guild: discord.Guild,
+        channel: discord.Thread,
+        member: discord.Member,
+        actor: discord.abc.User,
+        is_mute: bool,
+        thread_ids: list[int],
+        muted_until,
+        reason: Optional[str],
+        duration_label: str,
+    ) -> None:
+        """后台执行全贴禁言/撤销，完成后通知执行者。"""
+        try:
+            if is_mute:
+                affected = await self._apply_global_thread_mute(
+                    guild.id,
+                    thread_ids,
+                    member,
+                    actor,
+                    muted_until=muted_until,
+                    reason=reason,
+                    duration_label=duration_label,
+                    announce_channel=channel,
+                )
+                result = (
+                    "✅ **全贴禁言完成**\n\n"
+                    f"**用户：** {member.mention}\n\n"
+                    f"**影响帖子：** {affected} 个"
+                )
+            else:
+                affected, still_single = await self._apply_global_thread_unmute(
+                    guild.id,
+                    thread_ids,
+                    member,
+                    actor,
+                    announce_channel=channel,
+                )
+                result = (
+                    "✅ **已撤销全贴禁言**\n\n"
+                    f"**用户：** {member.mention}\n\n"
+                    f"**撤销全贴层帖子：** {affected} 个\n\n"
+                    f"**仍有单帖禁言帖子：** {still_single} 个"
+                )
+            await self._notify_background_result(guild, channel, actor, result)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(
+                    f"后台全贴禁言流程失败: guild={guild.id} user={member.id} - {e}"
+                )
+            try:
+                await self._notify_background_result(
+                    guild, channel, actor, f"❌ 操作失败：{e}"
+                )
+            except Exception:
+                pass
+
+    async def _notify_background_result(
+        self,
+        guild: discord.Guild,
+        channel: discord.Thread,
+        actor: discord.abc.User,
+        text: str,
+    ) -> None:
+        """后台结果优先私信执行者，失败时降级为在帖子内发送。"""
+        try:
+            await dm.send_dm(guild, actor, text)
+            return
+        except Exception as e:
+            if self.logger:
+                self.logger.warning(f"后台结果私信通知失败: user={actor.id} - {e}")
+        try:
+            await channel.send(text)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"后台结果帖内通知失败: channel={channel.id} - {e}")
 
     async def apply_slowmode_from_menu(self, interaction: discord.Interaction, channel: discord.Thread, seconds: int):
         label = next((n for n, s in SLOWMODE_OPTIONS if s == seconds), str(seconds))
@@ -1787,6 +2049,25 @@ class ThreadSelfManage(commands.Cog):
             record.setdefault("global_muted_until", None)
         return record
 
+    async def _apply_mute_by_ids(
+        self,
+        guild_id: int,
+        thread_id: int,
+        user_id: int,
+        muted_until,
+        scope: str,
+        bulk: Optional[list] = None,
+    ) -> bool:
+        """按 (guild_id, thread_id, user_id) 写入禁言层，不依赖 Thread 对象。"""
+        if scope not in {"thread", "global"}:
+            raise ValueError(f"未知禁言范围: {scope}")
+        record = self._get_mute_record(guild_id, thread_id, user_id)
+        field = "global_muted_until" if scope == "global" else "muted_until"
+        record[field] = muted_until
+        record["violations"] = 0
+        await self._save_mute_record(guild_id, thread_id, user_id, record, bulk=bulk)
+        return True
+
     async def _mute_thread_user(
         self,
         channel: discord.Thread,
@@ -1799,8 +2080,13 @@ class ThreadSelfManage(commands.Cog):
         duration_label: str = "永久",
         announcement_title: str = "🔒 子区禁言",
         scope: str = "thread",
+        bulk: Optional[list] = None,
     ) -> bool:
-        """统一禁言实现；scope 决定写入单帖层还是全贴层。"""
+        """统一禁言实现；scope 决定写入单帖层还是全贴层。
+
+        bulk 为可选收集列表：传入时仅更新内存缓存并暂存待写记录，
+        由调用方在循环结束后统一提交（批量场景减少 commit 次数）。
+        """
         if scope not in {"thread", "global"}:
             raise ValueError(f"未知禁言范围: {scope}")
         if announce:
@@ -1815,36 +2101,32 @@ class ThreadSelfManage(commands.Cog):
             embed.add_field(name="执行者", value=actor.mention, inline=True)
             await channel.send(embed=embed)
 
-        record = self._get_mute_record(channel.guild.id, channel.id, member.id)
-        field = "global_muted_until" if scope == "global" else "muted_until"
-        record[field] = muted_until
-        record["violations"] = 0
-        await self._save_mute_record(channel.guild.id, channel.id, member.id, record)
-        return True
+        return await self._apply_mute_by_ids(
+            channel.guild.id, channel.id, member.id, muted_until, scope, bulk
+        )
 
-    async def _unmute_thread_user(
+    async def _apply_unmute_by_ids(
         self,
-        channel: discord.Thread,
-        member: discord.Member,
-        *,
-        actor: discord.abc.User,
-        announce: bool,
-        scope: str = "thread",
-    ) -> bool:
-        """统一解除实现；仅清除指定层，另一层不受影响。"""
+        guild_id: int,
+        thread_id: int,
+        user_id: int,
+        scope: str,
+        bulk: Optional[list] = None,
+    ) -> tuple[bool, bool]:
+        """按 id 解除指定层，返回 (是否解除, 是否仍有单帖层)。"""
         if scope not in {"thread", "global"}:
             raise ValueError(f"未知禁言范围: {scope}")
-        key = (channel.guild.id, channel.id, member.id)
+        key = (guild_id, thread_id, user_id)
         record = self._mute_cache.get(key)
         if not record:
-            return False
+            return False, False
 
         single_active, global_active = await self._refresh_mute_layers(
-            channel.guild.id, channel.id, member.id
+            guild_id, thread_id, user_id
         )
         active = global_active if scope == "global" else single_active
         if not active:
-            return False
+            return False, False
 
         field = "global_muted_until" if scope == "global" else "muted_until"
         record = self._mute_cache.get(key, record)
@@ -1854,11 +2136,34 @@ class ThreadSelfManage(commands.Cog):
             record.get("global_muted_until")
         )
         await self._save_mute_record(
-            channel.guild.id,
-            channel.id,
-            member.id,
+            guild_id,
+            thread_id,
+            user_id,
             record if remaining_single or remaining_global else None,
+            bulk=bulk,
         )
+        return True, remaining_single
+
+    async def _unmute_thread_user(
+        self,
+        channel: discord.Thread,
+        member: discord.Member,
+        *,
+        actor: discord.abc.User,
+        announce: bool,
+        scope: str = "thread",
+        bulk: Optional[list] = None,
+    ) -> bool:
+        """统一解除实现；仅清除指定层，另一层不受影响。
+
+        bulk 为可选收集列表：语义同 _mute_thread_user。
+        """
+        removed, remaining_single = await self._apply_unmute_by_ids(
+            channel.guild.id, channel.id, member.id, scope, bulk
+        )
+        if not removed:
+            return False
+
         if announce:
             is_global = scope == "global"
             embed = discord.Embed(
@@ -1882,13 +2187,24 @@ class ThreadSelfManage(commands.Cog):
             await channel.send(embed=embed)
         return True
 
-    async def _save_mute_record(self, guild_id: int, thread_id: int, user_id: int, record: dict):
+    async def _save_mute_record(
+        self,
+        guild_id: int,
+        thread_id: int,
+        user_id: int,
+        record: dict,
+        bulk: Optional[list] = None,
+    ):
         # 更新内存缓存
         key = (guild_id, thread_id, user_id)
         if record:
             self._mute_cache[key] = record
         else:
             self._mute_cache.pop(key, None)
+        # 批量模式：仅暂存，由调用方循环结束后统一提交
+        if bulk is not None:
+            bulk.append((guild_id, thread_id, user_id, record if record else None))
+            return
         # 持久化到数据库
         try:
             await db.save_mute_record(guild_id, thread_id, user_id, record if record else None)

--- a/src/thread_manage/db.py
+++ b/src/thread_manage/db.py
@@ -416,6 +416,46 @@ async def save_mute_record(guild_id: int, thread_id: int, user_id: int,
     await _db.commit()
 
 
+async def save_mute_records_bulk(records: list[tuple[int, int, int, Optional[dict]]]) -> None:
+    """批量保存或删除禁言记录，单个事务提交。
+
+    records 元素为 (guild_id, thread_id, user_id, record)；record 为 None 时删除。
+    用于全贴禁言/撤销等大批量场景，将 N 次独立 commit 合并为一次。
+    """
+    if not records:
+        return
+    upserts = [
+        (
+            guild_id,
+            thread_id,
+            user_id,
+            record.get("muted_until"),
+            record.get("global_muted_until"),
+            record.get("violations", 0),
+        )
+        for guild_id, thread_id, user_id, record in records
+        if record
+    ]
+    deletes = [
+        (guild_id, thread_id, user_id)
+        for guild_id, thread_id, user_id, record in records
+        if not record
+    ]
+    if upserts:
+        await _db.executemany(
+            "INSERT OR REPLACE INTO thread_mutes "
+            "(guild_id, thread_id, user_id, muted_until, global_muted_until, violations) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            upserts,
+        )
+    if deletes:
+        await _db.executemany(
+            "DELETE FROM thread_mutes WHERE guild_id = ? AND thread_id = ? AND user_id = ?",
+            deletes,
+        )
+    await _db.commit()
+
+
 # ── 论坛 Opt-out 操作 ───────────────────────────────────────
 
 async def load_forum_optout() -> set[int]:

--- a/tests/test_thread_global_mute.py
+++ b/tests/test_thread_global_mute.py
@@ -17,6 +17,8 @@ def make_cog() -> ThreadSelfManage:
     cog = ThreadSelfManage.__new__(ThreadSelfManage)
     cog.logger = MagicMock()
     cog._mute_cache = {}
+    cog._thread_owner_cache = {}
+    cog._thread_owner_ready = set()
     return cog
 
 
@@ -134,7 +136,7 @@ async def test_global_thread_action_permission_excludes_delegate(
     assert await cog.can_global_thread_action(interaction, thread) is expected
 
 
-async def test_find_owned_forum_threads_includes_active_and_archived(monkeypatch):
+async def test_scan_all_forum_threads_builds_owner_index(monkeypatch):
     cog = make_cog()
 
     class FakeForum:
@@ -161,9 +163,9 @@ async def test_find_owned_forum_threads_includes_active_and_archived(monkeypatch
     )
     guild = SimpleNamespace(channels=[forum, SimpleNamespace(id=100)])
 
-    result = await cog._find_owned_forum_threads(guild, 42)
+    result = await cog._scan_all_forum_threads(guild)
 
-    assert [thread.id for thread in result] == [1, 3]
+    assert result == {42: {1, 3}, 7: {2}}
 
 
 async def test_global_mute_scans_current_thread_owner_posts(monkeypatch):
@@ -181,7 +183,8 @@ async def test_global_mute_scans_current_thread_owner_posts(monkeypatch):
         original_response=AsyncMock(return_value=message),
     )
     cog.can_global_thread_action = AsyncMock(return_value=True)
-    cog._find_owned_forum_threads = AsyncMock(return_value=[])
+    cog._build_owner_index = AsyncMock()
+    cog._lookup_owned_threads = MagicMock(return_value=[])
     cog._apply_global_thread_mute = AsyncMock(return_value=0)
     monkeypatch.setattr(
         "src.thread_manage.cog.wait_menu_confirm_on_message",
@@ -192,89 +195,99 @@ async def test_global_mute_scans_current_thread_owner_posts(monkeypatch):
         interaction, source, target, is_mute=True
     )
 
-    cog._find_owned_forum_threads.assert_awaited_once_with(guild, 10)
+    cog._build_owner_index.assert_awaited_once_with(guild)
+    cog._lookup_owned_threads.assert_called_once_with(guild, 10)
 
 
-async def test_global_mute_announces_only_in_source_thread():
-    """全贴禁言仅在执行指令的当前帖子公示，其他帖子保持静默。"""
+async def test_global_mute_announces_only_in_source_thread(monkeypatch):
+    """全贴禁言仅在执行指令的当前帖子公示，其他帖子静默按 id 写库。"""
     cog = make_cog()
-    threads = [SimpleNamespace(id=100), SimpleNamespace(id=101)]
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_records_bulk", AsyncMock())
+    announce_channel = SimpleNamespace(id=100, send=AsyncMock())
     target = SimpleNamespace(id=42)
     actor = SimpleNamespace(id=10)
-    cog._mute_thread_user = AsyncMock(side_effect=[True, True])
+    cog._mute_thread_user = AsyncMock(return_value=True)
+    cog._apply_mute_by_ids = AsyncMock(return_value=True)
 
     affected = await cog._apply_global_thread_mute(
-        threads,
-        target,
-        actor,
-        announce_thread_id=100,
+        7, [100, 101], target, actor, announce_channel=announce_channel
     )
 
     assert affected == 2
-    calls = cog._mute_thread_user.await_args_list
-    assert calls[0].args[1] is target
-    assert calls[0].kwargs["announce"] is True
-    assert calls[0].kwargs["announcement_title"] == "🔒 全贴禁言"
-    assert calls[1].args[1] is target
-    assert calls[1].kwargs["announce"] is False
-    assert calls[1].kwargs["announcement_title"] == "🔒 全贴禁言"
+    cog._mute_thread_user.assert_awaited_once()
+    announce_call = cog._mute_thread_user.await_args
+    assert announce_call.args[0] is announce_channel
+    assert announce_call.kwargs["announce"] is True
+    assert announce_call.kwargs["announcement_title"] == "🔒 全贴禁言"
+    cog._apply_mute_by_ids.assert_awaited_once()
+    assert cog._apply_mute_by_ids.await_args.args[:5] == (7, 101, 42, -1, "global")
 
 
-async def test_apply_global_thread_mute_reuses_single_thread_mute_helper():
+async def test_apply_global_thread_mute_uses_bulk_helper_for_non_announce(monkeypatch):
     cog = make_cog()
-    threads = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_records_bulk", AsyncMock())
     member = SimpleNamespace(id=42)
     actor = SimpleNamespace(id=10)
-    cog._mute_thread_user = AsyncMock(side_effect=[True, True])
+    cog._mute_thread_user = AsyncMock(return_value=True)
+    cog._apply_mute_by_ids = AsyncMock(return_value=True)
 
-    affected = await cog._apply_global_thread_mute(threads, member, actor)
+    affected = await cog._apply_global_thread_mute(7, [1, 2], member, actor)
 
     assert affected == 2
-    assert cog._mute_thread_user.await_count == 2
-    for call in cog._mute_thread_user.await_args_list:
-        assert call.kwargs["muted_until"] == -1
-        assert call.kwargs["announce"] is False
+    cog._mute_thread_user.assert_not_awaited()
+    assert cog._apply_mute_by_ids.await_count == 2
+    for call in cog._apply_mute_by_ids.await_args_list:
+        assert call.args[0] == 7
+        assert call.args[3] == -1
+        assert call.args[4] == "global"
 
 
-async def test_apply_global_thread_mute_forwards_custom_mute_parameters():
+async def test_apply_global_thread_mute_forwards_custom_mute_parameters(monkeypatch):
     """防止批量入口丢失直接命令传入的时长、原因或显示标签。"""
     cog = make_cog()
-    threads = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_records_bulk", AsyncMock())
+    announce_channel = SimpleNamespace(id=1, send=AsyncMock())
     member = SimpleNamespace(id=42)
     actor = SimpleNamespace(id=10)
-    cog._mute_thread_user = AsyncMock(side_effect=[True, True])
+    cog._mute_thread_user = AsyncMock(return_value=True)
+    cog._apply_mute_by_ids = AsyncMock(return_value=True)
 
-    affected = await cog._apply_global_thread_mute(
-        threads,
+    await cog._apply_global_thread_mute(
+        7,
+        [1, 2],
         member,
         actor,
         muted_until="2026-07-27T12:00:00",
         reason="跨帖测试",
         duration_label="1d",
+        announce_channel=announce_channel,
     )
 
-    assert affected == 2
-    for call in cog._mute_thread_user.await_args_list:
-        assert call.kwargs["muted_until"] == "2026-07-27T12:00:00"
-        assert call.kwargs["reason"] == "跨帖测试"
-        assert call.kwargs["duration_label"] == "1d"
-        assert call.kwargs["announce"] is False
+    announce_call = cog._mute_thread_user.await_args
+    assert announce_call.kwargs["muted_until"] == "2026-07-27T12:00:00"
+    assert announce_call.kwargs["reason"] == "跨帖测试"
+    assert announce_call.kwargs["duration_label"] == "1d"
+    assert cog._apply_mute_by_ids.await_args.args[3] == "2026-07-27T12:00:00"
 
 
-async def test_apply_global_thread_unmute_only_counts_existing_records():
+async def test_apply_global_thread_unmute_only_counts_existing_records(monkeypatch):
     cog = make_cog()
-    threads = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_records_bulk", AsyncMock())
     member = SimpleNamespace(id=42)
     actor = SimpleNamespace(id=10)
-    cog._unmute_thread_user = AsyncMock(side_effect=[True, False])
+    cog._apply_unmute_by_ids = AsyncMock(
+        side_effect=[(True, False), (False, False)]
+    )
 
-    affected = await cog._apply_global_thread_unmute(threads, member, actor)
+    affected, still_single = await cog._apply_global_thread_unmute(
+        7, [1, 2], member, actor
+    )
 
-    assert affected == (1, 0)
-    assert cog._unmute_thread_user.await_count == 2
-    for call in cog._unmute_thread_user.await_args_list:
-        assert call.kwargs["announce"] is False
-        assert call.kwargs["scope"] == "global"
+    assert (affected, still_single) == (1, 0)
+    assert cog._apply_unmute_by_ids.await_count == 2
+    for call in cog._apply_unmute_by_ids.await_args_list:
+        assert call.args[0] == 7
+        assert call.args[3] == "global"
 
 
 async def test_global_unmute_clears_global_layer_and_preserves_single_layer(monkeypatch):
@@ -306,50 +319,44 @@ async def test_global_unmute_clears_global_layer_and_preserves_single_layer(monk
     assert await cog._is_thread_muted(1, 50, 42) is True
 
 
-async def test_global_unmute_returns_removed_and_still_single_counts():
+async def test_global_unmute_returns_removed_and_still_single_counts(monkeypatch):
     """批量撤销只统计实际全贴层，并报告撤销后仍有单帖层的帖子。"""
     cog = make_cog()
-    threads = [SimpleNamespace(id=1), SimpleNamespace(id=2), SimpleNamespace(id=3)]
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_records_bulk", AsyncMock())
     member = SimpleNamespace(id=42)
     actor = SimpleNamespace(id=10)
-    cog._mute_cache = {
-        (1, 1, 42): {"muted_until": -1, "global_muted_until": -1},
-        (1, 2, 42): {"muted_until": None, "global_muted_until": -1},
-        (1, 3, 42): {"muted_until": -1, "global_muted_until": None},
-    }
-    for thread in threads:
-        thread.guild = SimpleNamespace(id=1)
-    cog._unmute_thread_user = AsyncMock(side_effect=[True, True, False])
-
-    result = await cog._apply_global_thread_unmute(threads, member, actor)
-
-    assert result == (2, 1)
-    for call in cog._unmute_thread_user.await_args_list:
-        assert call.kwargs["scope"] == "global"
-
-
-async def test_global_unmute_announces_only_in_source_thread():
-    """解除全贴禁言公示只发送到执行命令的当前帖子。"""
-    cog = make_cog()
-    source = SimpleNamespace(id=1, guild=SimpleNamespace(id=7))
-    other = SimpleNamespace(id=2, guild=SimpleNamespace(id=7))
-    member = SimpleNamespace(id=42)
-    actor = SimpleNamespace(id=10)
-    cog._unmute_thread_user = AsyncMock(side_effect=[True, True])
-    cog._mute_cache = {
-        (7, 1, 42): {"muted_until": -1, "global_muted_until": -1},
-        (7, 2, 42): {"muted_until": None, "global_muted_until": -1},
-    }
-
-    await cog._apply_global_thread_unmute(
-        [source, other], member, actor, announce_thread_id=1
+    cog._apply_unmute_by_ids = AsyncMock(
+        side_effect=[(True, True), (True, False), (False, False)]
     )
 
-    calls = cog._unmute_thread_user.await_args_list
-    assert calls[0].kwargs["announce"] is True
-    assert calls[0].kwargs["scope"] == "global"
-    assert calls[1].kwargs["announce"] is False
-    assert calls[1].kwargs["scope"] == "global"
+    result = await cog._apply_global_thread_unmute(7, [1, 2, 3], member, actor)
+
+    assert result == (2, 1)
+    for call in cog._apply_unmute_by_ids.await_args_list:
+        assert call.args[3] == "global"
+
+
+async def test_global_unmute_announces_only_in_source_thread(monkeypatch):
+    """解除全贴禁言公示只发送到执行命令的当前帖子。"""
+    cog = make_cog()
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_records_bulk", AsyncMock())
+    announce_channel = SimpleNamespace(id=1, send=AsyncMock())
+    member = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+    cog._unmute_thread_user = AsyncMock(return_value=True)
+    cog._apply_unmute_by_ids = AsyncMock(return_value=(True, False))
+
+    await cog._apply_global_thread_unmute(
+        7, [1, 2], member, actor, announce_channel=announce_channel
+    )
+
+    cog._unmute_thread_user.assert_awaited_once()
+    announce_call = cog._unmute_thread_user.await_args
+    assert announce_call.args[0] is announce_channel
+    assert announce_call.kwargs["announce"] is True
+    assert announce_call.kwargs["scope"] == "global"
+    cog._apply_unmute_by_ids.assert_awaited_once()
+    assert cog._apply_unmute_by_ids.await_args.args[:3] == (7, 2, 42)
 
 
 @pytest.mark.parametrize(
@@ -825,3 +832,175 @@ async def test_global_unmute_slash_command_reuses_existing_flow(monkeypatch):
         member,
         is_mute=False,
     )
+
+
+async def test_global_mute_collects_records_for_single_commit(monkeypatch):
+    """批量禁言通过收集列表一次性提交，而非逐帖 commit。"""
+    cog = make_cog()
+    bulk_save = AsyncMock()
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_records_bulk", bulk_save)
+    member = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+
+    affected = await cog._apply_global_thread_mute(7, [1, 2], member, actor)
+
+    assert affected == 2
+    bulk_save.assert_awaited_once()
+    records = bulk_save.await_args.args[0]
+    assert len(records) == 2
+    keys = {(g, t, u) for g, t, u, _ in records}
+    assert keys == {(7, 1, 42), (7, 2, 42)}
+    assert all(rec[3] is not None for rec in records)
+
+
+async def test_global_unmute_collects_deletes_for_single_commit(monkeypatch):
+    """批量撤销收集删除记录并一次性提交，不逐帖 commit。"""
+    cog = make_cog()
+    bulk_save = AsyncMock()
+    monkeypatch.setattr("src.thread_manage.cog.db.save_mute_records_bulk", bulk_save)
+    member = SimpleNamespace(id=42)
+    actor = SimpleNamespace(id=10)
+    cog._mute_cache[(7, 1, 42)] = {
+        "muted_until": None,
+        "global_muted_until": -1,
+        "violations": 0,
+    }
+
+    affected, still_single = await cog._apply_global_thread_unmute(
+        7, [1], member, actor
+    )
+
+    assert (affected, still_single) == (1, 0)
+    bulk_save.assert_awaited_once()
+    records = bulk_save.await_args.args[0]
+    assert len(records) == 1
+    assert records[0][:3] == (7, 1, 42)
+    assert records[0][3] is None  # 全清后删除记录
+
+
+async def test_global_action_backgrounds_when_over_threshold(monkeypatch):
+    """影响帖子数超过阈值时，转为后台执行而非同步批量处理。"""
+    cog = make_cog()
+    cog._GLOBAL_BACKGROUND_THRESHOLD = 2
+    cog.can_global_thread_action = AsyncMock(return_value=True)
+    source = SimpleNamespace(id=100, owner_id=10)
+    target = SimpleNamespace(id=42, mention="<@42>")
+    guild = SimpleNamespace(
+        id=1,
+        get_member=lambda user_id: SimpleNamespace(mention="<@10>") if user_id == 10 else None,
+    )
+    message = SimpleNamespace(edit=AsyncMock())
+    interaction = SimpleNamespace(
+        guild=guild,
+        user=SimpleNamespace(id=10, mention="<@10>"),
+        response=SimpleNamespace(defer=AsyncMock()),
+        original_response=AsyncMock(return_value=message),
+    )
+    cog._build_owner_index = AsyncMock()
+    cog._lookup_owned_threads = MagicMock(return_value=[1, 2, 3])
+    cog._apply_global_thread_mute = AsyncMock()
+    cog._start_background_global_action = AsyncMock()
+    monkeypatch.setattr(
+        "src.thread_manage.cog.wait_menu_confirm_on_message",
+        AsyncMock(return_value=True),
+    )
+
+    await cog.menu_run_global_thread_action(
+        interaction, source, target, is_mute=True
+    )
+
+    cog._start_background_global_action.assert_awaited_once()
+    cog._apply_global_thread_mute.assert_not_awaited()
+
+
+async def test_global_action_sync_when_under_threshold(monkeypatch):
+    """影响帖子数未超阈值时，保持同步批量处理。"""
+    cog = make_cog()
+    cog._GLOBAL_BACKGROUND_THRESHOLD = 2
+    cog.can_global_thread_action = AsyncMock(return_value=True)
+    source = SimpleNamespace(id=100, owner_id=10)
+    target = SimpleNamespace(id=42, mention="<@42>")
+    guild = SimpleNamespace(
+        id=1,
+        get_member=lambda user_id: SimpleNamespace(mention="<@10>") if user_id == 10 else None,
+    )
+    message = SimpleNamespace(edit=AsyncMock())
+    interaction = SimpleNamespace(
+        guild=guild,
+        user=SimpleNamespace(id=10, mention="<@10>"),
+        response=SimpleNamespace(defer=AsyncMock()),
+        original_response=AsyncMock(return_value=message),
+    )
+    cog._build_owner_index = AsyncMock()
+    cog._lookup_owned_threads = MagicMock(return_value=[1])
+    cog._apply_global_thread_mute = AsyncMock(return_value=1)
+    cog._start_background_global_action = AsyncMock()
+    monkeypatch.setattr(
+        "src.thread_manage.cog.wait_menu_confirm_on_message",
+        AsyncMock(return_value=True),
+    )
+
+    await cog.menu_run_global_thread_action(
+        interaction, source, target, is_mute=True
+    )
+
+    cog._start_background_global_action.assert_not_awaited()
+    cog._apply_global_thread_mute.assert_awaited_once()
+
+
+async def test_notify_background_result_prefers_dm(monkeypatch):
+    """后台结果优先私信执行者，成功时不发帖内消息。"""
+    cog = make_cog()
+    send_dm = AsyncMock()
+    monkeypatch.setattr("src.thread_manage.cog.dm.send_dm", send_dm)
+    guild = SimpleNamespace(id=1)
+    channel = SimpleNamespace(id=10, send=AsyncMock())
+    actor = SimpleNamespace(id=42)
+
+    await cog._notify_background_result(guild, channel, actor, "完成")
+
+    send_dm.assert_awaited_once_with(guild, actor, "完成")
+    channel.send.assert_not_awaited()
+
+
+async def test_notify_background_result_falls_back_to_channel(monkeypatch):
+    """私信失败时，降级为在帖子内发送结果。"""
+    cog = make_cog()
+    send_dm = AsyncMock(side_effect=Exception("no dm bot"))
+    monkeypatch.setattr("src.thread_manage.cog.dm.send_dm", send_dm)
+    guild = SimpleNamespace(id=1)
+    channel = SimpleNamespace(id=10, send=AsyncMock())
+    actor = SimpleNamespace(id=42)
+
+    await cog._notify_background_result(guild, channel, actor, "完成")
+
+    send_dm.assert_awaited_once()
+    channel.send.assert_awaited_once_with("完成")
+
+
+async def test_background_mute_notifies_actor_on_completion(monkeypatch):
+    """后台禁言完成后，将结果通知给执行者。"""
+    cog = make_cog()
+    notify = AsyncMock()
+    cog._notify_background_result = notify
+    cog._apply_global_thread_mute = AsyncMock(return_value=5)
+    guild = SimpleNamespace(id=1)
+    channel = SimpleNamespace(id=10)
+    member = SimpleNamespace(id=42, mention="<@42>")
+    actor = SimpleNamespace(id=10)
+
+    await cog._run_global_action_in_background(
+        guild=guild,
+        channel=channel,
+        member=member,
+        actor=actor,
+        is_mute=True,
+        thread_ids=[1],
+        muted_until=-1,
+        reason="测试",
+        duration_label="永久",
+    )
+
+    notify.assert_awaited_once()
+    text = notify.await_args.args[3]
+    assert "5 个" in text


### PR DESCRIPTION
## 概述
优化「全贴禁言 / 撤销全贴禁言」在大帖子数场景下的性能。

## 背景
原实现每次全贴禁言都会全站遍历论坛帖子，帖子数多时耗时显著、频繁调用 Discord API，且容易触发交互超时。本次改为「懒加载楼主索引 + 按 ID 写库」的方式。

## 主要变更
- **懒加载楼主索引**：新增 `_thread_owner_cache` / `_thread_owner_ready`，
  首次全贴操作时全站扫描一次建立 `{owner_id: {thread_id}}` 索引，之后命中缓存；
  并通过 `on_thread_create/update/delete/on_guild_remove` 增量维护。
- **按 ID 写库**：`_apply_global_thread_mute/unmute` 改为接收 `thread_ids`，
  不再依赖 `discord.Thread` 对象，减少对象依赖与 API 调用；
  新增 `_apply_mute_by_ids` / `_apply_unmute_by_ids`。
- **批量提交**：新增 `save_mute_records_bulk`，将 N 次独立 commit 合并为一次事务提交。
- **并发处理**：使用 `asyncio.Semaphore` 控制并发写库，避免逐帖串行。
- **后台任务**：影响帖子数超过阈值时转入后台执行，完成后私信通知执行者，避免交互超时。

## 测试
- `tests/test_thread_global_mute.py` 全部通过（47 项）。